### PR TITLE
symplectic integrator of any order

### DIFF
--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -1,7 +1,6 @@
 """pmwd: particle mesh with derivatives"""
 
 
-from pmwd.tree_util import pytree_dataclass
 from pmwd.configuration import Configuration
 from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18, E2, H_deriv, Omega_m_a
 from pmwd.boltzmann import (transfer_integ, transfer_fit, transfer,
@@ -14,7 +13,6 @@ from pmwd.gravity import laplace, neg_grad, gravity
 from pmwd.modes import white_noise, linear_modes
 from pmwd.lpt import lpt
 from pmwd.nbody import nbody
-from pmwd.pm_util import enmesh, rfftnfreq
 try:
     from pmwd._version import __version__
 except ModuleNotFoundError:

--- a/pmwd/configuration.py
+++ b/pmwd/configuration.py
@@ -126,6 +126,10 @@ class Configuration:
 
     chunk_size: int = 2**24
 
+    # padded and cumsumed symplectic coefs
+    symp_cd: jnp.ndarray = jnp.array([[0, 0, 1], [0, 0.5, 1]], dtype=float_dtype)
+    symp_order: Optional[int] = None
+
     def __post_init__(self):
         if self._is_transforming():
             return
@@ -158,6 +162,9 @@ class Configuration:
             object.__setattr__(self, 'growth_rtol', growth_tol)
         if self.growth_atol is None:
             object.__setattr__(self, 'growth_atol', growth_tol)
+
+        if self.symp_order is None:
+            object.__setattr__(self, 'symp_order', self.symp_cd.shape[1] - 1)
 
         dtype = self.cosmo_dtype
         for name, value in self.named_children():

--- a/pmwd/lpt.py
+++ b/pmwd/lpt.py
@@ -93,8 +93,7 @@ def levi_civita(indices):
 
     dim = len(indices)
     lohi = tuple(combinations(range(dim), r=2))
-    lohi = jnp.array(lohi).T
-    lo, hi = lohi[0], lohi[1]  # https://github.com/google/jax/issues/1583
+    lo, hi = jnp.array(lohi).T
 
     epsilon = jnp.sign(indices[hi] - indices[lo]).prod()
 

--- a/pmwd/pm_util.py
+++ b/pmwd/pm_util.py
@@ -14,6 +14,7 @@ def _chunk_split(ptcl_num, chunk_size, *arrays):
         remainder = [x[:remainder_size] if x.ndim != 0 else x for x in arrays]
         chunks = [x[remainder_size:] if x.ndim != 0 else x for x in arrays]
 
+    # `scan` triggers errors in scatter and gather without the `full`
     chunks = [x.reshape(chunk_num, chunk_size, *x.shape[1:]) if x.ndim != 0
               else jnp.full(chunk_num, x) for x in chunks]
 


### PR DESCRIPTION
1. We adapt the code for the flexibility of using a symplectic integrator of any order. The user could set the coefficients (e.g. the default [[0, 0, 1], [0, 0.5, 1]] for leapfrog) in configuration. 
2. The loop over a_nbody is also switched from (a_prev, a_next) to index i. This is not necessary for the symplectic upgrade, but would make things easier for implementing observables.