### PR TITLE
Refactor Configuration and API change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,9 @@
    :alt: logo
 
 
+##############################
 particle mesh with derivatives
-==============================
+##############################
 
 ``pmwd`` is a differentiable cosmological particle-mesh forward model.
 The C\ :sub:`2` symmetry of the name symbolizes the reversibility of the
@@ -29,8 +30,9 @@ interesting projected patterns.
   <video src="https://user-images.githubusercontent.com/7311098/212061152-2b1be0ac-bfc4-4b57-87fe-d5b9b5c38e8c.mp4"></video>
 
 
+************
 Installation
-------------
+************
 
 .. code:: sh
 
@@ -41,15 +43,19 @@ Installation
   pip install -e .[dev]  # to install development dependencies
 
 
+********
 Examples
---------
+********
 
 See `docs/examples <docs/examples>`_.
 
 
 ..
+  *******
   Testing
-  -------
+  *******
+  pytest-mypy
+  pytest-mypy-testing
 
   .. code:: sh
 
@@ -70,8 +76,9 @@ See `docs/examples <docs/examples>`_.
 
 
 ..
+  **********************
   References & Citations
-  ----------------------
+  **********************
 
   We refer the users to the following references for ...
   Please cite the following papers:

--- a/docs/papers/adjoint/grads.py
+++ b/docs/papers/adjoint/grads.py
@@ -85,9 +85,9 @@ else:  # making plots
     from matplotlib.colors import SymLogNorm, LogNorm
     plt.style.use('adjoint.mplstyle')
 
-    fig, _ = simshow(gam[0, 32], figsize=(3.5, 2.7), cmap='RdBu_r',
-                     norm=SymLogNorm(0.01, vmin=-0.1, vmax=0.1), colorbar=True,
-                     interpolation='none')
+    fig, _, _ = simshow(gam[0, 32], figsize=(3.5, 2.7), cmap='RdBu_r',
+                        norm=SymLogNorm(0.01, vmin=-0.1, vmax=0.1), colorbar=True,
+                        interpolation='none')
     fig.savefig('grads.pdf')
     plt.close(fig)
 

--- a/docs/papers/adjoint/slab.py
+++ b/docs/papers/adjoint/slab.py
@@ -33,6 +33,6 @@ modes = white_noise(seed, conf)
 
 dens = model(modes, cosmo, conf)
 
-fig, _ = simshow(dens[:16].mean(axis=0), norm='CosmicWebNorm')
+fig, _, _ = simshow(dens[:16].mean(axis=0), norm='CosmicWebNorm')
 fig.savefig('slab.pdf')
 plt.close(fig)

--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -4,7 +4,7 @@
 from pmwd.configuration import Configuration
 from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18, E2, H_deriv, Omega_m_a
 from pmwd.boltzmann import (transfer_integ, transfer_fit, transfer, growth_integ,
-                            growth, varlin_integ, varlin, boltzmann, linear_power)
+                            growth, varlin_integ, varlin, boltz, linear_power)
 from pmwd.particles import (Particles, ptcl_enmesh,
                             ptcl_pos, ptcl_rpos, ptcl_rsd, ptcl_los)
 from pmwd.scatter import scatter

--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -2,7 +2,8 @@
 
 
 from pmwd.configuration import Configuration
-from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18, E2, H_deriv, Omega_m_a
+from pmwd.cosmology import (Cosmology, SimpleLCDM, Planck18, E2, H_deriv, Omega_m_a,
+                            distance_tab, distance)
 from pmwd.boltzmann import (transfer_tab, transfer_fit, transfer, growth_tab, growth,
                             varlin_tab, varlin, linear_power)
 from pmwd.particles import (Particles, ptcl_enmesh,

--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -3,8 +3,8 @@
 
 from pmwd.configuration import Configuration
 from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18, E2, H_deriv, Omega_m_a
-from pmwd.boltzmann import (transfer_integ, transfer_fit, transfer, growth_integ,
-                            growth, varlin_integ, varlin, boltz, linear_power)
+from pmwd.boltzmann import (transfer_tab, transfer_fit, transfer, growth_tab, growth,
+                            varlin_tab, varlin, linear_power)
 from pmwd.particles import (Particles, ptcl_enmesh,
                             ptcl_pos, ptcl_rpos, ptcl_rsd, ptcl_los)
 from pmwd.scatter import scatter

--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -1,20 +1,39 @@
 """pmwd: particle mesh with derivatives"""
 
 
-from pmwd.configuration import Configuration
-from pmwd.cosmology import (Cosmology, SimpleLCDM, Planck18, E2, H_deriv, Omega_m_a,
-                            distance_tab, distance)
-from pmwd.boltzmann import (transfer_tab, transfer_fit, transfer, growth_tab, growth,
-                            varlin_tab, varlin, linear_power)
-from pmwd.particles import (Particles, ptcl_enmesh,
-                            ptcl_pos, ptcl_rpos, ptcl_rsd, ptcl_los)
+import jax
+import jax.numpy as jnp
+
+#print(f'{jnp.array(1.)!r}')
+
+#FIXME should use absolute in package __init__.py??
+#FIXME somehow JAX automatically enable x64 after the following line?
+from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18
+#print(f'{jnp.array(2.)!r}, NOTE dtype changes mysteriously now')
+from pmwd.background import E2, H_deriv, Omega_m_a, distance_cache, distance
+from pmwd.perturbation import (transfer_cache, transfer_fit, transfer,
+                               growth_cache, growth,
+                               varlin_cache, varlin,
+                               linear_power)
+from pmwd.solver import Solver
+from pmwd.modes import white_noise, linear_modes
+#from pmwd.particles import (Particles, ptcl_mass, ptcl_enmesh,  #FIXME conf problem
+#                            ptcl_rpos, ptcl_rsd, ptcl_los)
+from pmwd.particles import Particles, ptcl_mass
+#from pmwd.observables import FIXME
 from pmwd.scatter import scatter
 from pmwd.gather import gather
 from pmwd.gravity import laplace, neg_grad, gravity
-from pmwd.modes import white_noise, linear_modes
 from pmwd.lpt import lpt
 from pmwd.nbody import nbody
 try:
     from pmwd._version import __version__
 except ModuleNotFoundError:
     pass  # not installed
+
+
+#jax.config.update("jax_enable_x64", True)
+
+
+#move this to some style script for ipynb's, or the worst to every ipynb
+#jnp.set_printoptions(precision=3, edgeitems=2, linewidth=128)

--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -4,17 +4,15 @@
 import jax
 import jax.numpy as jnp
 
-#print(f'{jnp.array(1.)!r}')
 
-#FIXME should use absolute in package __init__.py??
-#FIXME somehow JAX automatically enable x64 after the following line?
-from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18
-#print(f'{jnp.array(2.)!r}, NOTE dtype changes mysteriously now')
+
+# TODO pmwd.cosmology.{background,perturbation,cosmology} ?
 from pmwd.background import E2, H_deriv, Omega_m_a, distance_cache, distance
 from pmwd.perturbation import (transfer_cache, transfer_fit, transfer,
                                growth_cache, growth,
                                varlin_cache, varlin,
                                linear_power)
+from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18
 from pmwd.solver import Solver
 from pmwd.modes import white_noise, linear_modes
 #from pmwd.particles import (Particles, ptcl_mass, ptcl_enmesh,  #FIXME conf problem
@@ -32,7 +30,8 @@ except ModuleNotFoundError:
     pass  # not installed
 
 
-#jax.config.update("jax_enable_x64", True)
+#FIXME bump version of mcfit (after disabled x64) and make that minimum requirement here
+#FIXME jax.config.update("jax_enable_x64", False)
 
 
 #move this to some style script for ipynb's, or the worst to every ipynb

--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -2,7 +2,7 @@
 
 
 # TODO pmwd.cosmology.{background,perturbation,cosmology} ?
-from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18
+from pmwd.cosmology import Cosmology, simple_LCDM, Planck_18
 from pmwd.background import E2, H_deriv, Omega_m_a, distance_cache, distance
 from pmwd.perturbation import (transfer_cache, transfer_fit, transfer,
                                growth_cache, growth,

--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -1,18 +1,13 @@
 """pmwd: particle mesh with derivatives"""
 
 
-import jax
-import jax.numpy as jnp
-
-
-
 # TODO pmwd.cosmology.{background,perturbation,cosmology} ?
+from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18
 from pmwd.background import E2, H_deriv, Omega_m_a, distance_cache, distance
 from pmwd.perturbation import (transfer_cache, transfer_fit, transfer,
                                growth_cache, growth,
                                varlin_cache, varlin,
                                linear_power)
-from pmwd.cosmology import Cosmology, SimpleLCDM, Planck18
 from pmwd.solver import Solver
 from pmwd.modes import white_noise, linear_modes
 #from pmwd.particles import (Particles, ptcl_mass, ptcl_enmesh,  #FIXME conf problem

--- a/pmwd/background.py
+++ b/pmwd/background.py
@@ -1,0 +1,240 @@
+from functools import partial
+
+from jax import value_and_grad
+import jax.numpy as jnp
+from jax.lax import switch
+
+
+def E2(a, cosmo):
+    """Squared relative Hubble parameter, :math:`E^2`, normalized at :math:`a=1`.
+
+    Parameters
+    ----------
+    a : ArrayLike
+        Scale factors.
+    cosmo : Cosmology
+
+    Returns
+    -------
+    E2 : jax.Array of cosmo.Omega_m.dtype
+        Squared relative Hubble parameter.
+
+    Notes
+    -----
+    The squared Hubble parameter,
+
+    .. math::
+
+        H^2(a) = H_0^2 E^2(a),
+
+    has the time dependence
+
+    .. math::
+
+        E^2(a) = \Omega_\mathrm{m} a^{-3} + \Omega_\mathrm{k} a^{-2}
+                 + \Omega_\mathrm{de} a^{-3 (1 + w_0 + w_a)} e^{-3 w_a (1 - a)}.
+
+    """
+    a = jnp.asarray(a, dtype=cosmo.Omega_m.dtype)
+
+    de_a = a**(-3 * (1 + cosmo.w_0 + cosmo.w_a)) * jnp.exp(-3 * cosmo.w_a * (1 - a))
+    return cosmo.Omega_m * a**-3 + cosmo.Omega_K * a**-2 + cosmo.Omega_de * de_a
+
+
+@partial(jnp.vectorize, excluded=(1,))
+def H_deriv(a, cosmo):
+    """Hubble parameter derivatives, :math:`\mathrm{d}\ln H / \mathrm{d}\ln a`.
+
+    Parameters
+    ----------
+    a : ArrayLike
+        Scale factors.
+    cosmo : Cosmology
+
+    Returns
+    -------
+    dlnH_dlna : jax.Array of cosmo.Omega_m.dtype
+        Hubble parameter derivatives.
+
+    """
+    a = jnp.asarray(a, dtype=cosmo.Omega_m.dtype)
+
+    E2_value, E2_grad = value_and_grad(E2)(a, cosmo)
+    return 0.5 * a * E2_grad / E2_value
+
+
+def Omega_m_a(a, cosmo):
+    r"""Matter density parameters, :math:`\Omega_\mathrm{m}(a)`.
+
+    Parameters
+    ----------
+    a : ArrayLike
+        Scale factors.
+    cosmo : Cosmology
+
+    Returns
+    -------
+    Omega : jax.Array of cosmo.Omega_m.dtype
+        Matter density parameters.
+
+    Notes
+    -----
+
+    .. math::
+
+        \Omega_\mathrm{m}(a) = \frac{\Omega_\mathrm{m} a^{-3}}{E^2(a)}
+
+    """
+    a = jnp.asarray(a, dtype=cosmo.Omega_m.dtype)
+
+    return cosmo.Omega_m / (a**3 * E2(a, cosmo))
+
+
+def distance_cache(cosmo):
+    r"""Cache the comoving and physical distance tables at ``cosmo.distance_a``.
+
+    Parameters
+    ----------
+    cosmo : Cosmology
+
+    Returns
+    -------
+    cosmo : Cosmology
+        A new instance containing a distance table, in unit :math:`L`, shape
+        ``(2, cosmo.distance_a_num,)``, and precision ``cosmo.Omega_m.dtype``.
+
+    Notes
+    -----
+    The comoving horizon in the conformal time :math:`\eta`
+
+    .. math::
+
+        c \eta = \int_0^t \frac{c \mathrm{d} t}{a(t)}
+               = d_H \int_0^a \frac{\mathrm{d} a'}{a'^2 E(a')}
+               = d_H \int_z^\infty \frac{\mathrm{d} z'}{E(z')}.
+
+    The light-travel distance in the age or physical time :math:`t`
+
+    .. math::
+
+        ct = \int_0^t c \mathrm{d} t
+           = d_H \int_0^a \frac{\mathrm{d} a'}{a' E(a')}
+           = d_H \int_z^\infty \frac{\mathrm{d} z'}{(1+z') E(z')}.
+
+    """
+    #FIXME in the future use jax.scipy.integrate.cumulative_trapezoid or Cubic Hermite spline antiderivatives
+    a = cosmo.distance_a[1:]
+    da = jnp.diff(cosmo.distance_a, prepend=0)
+
+    cdetada = cosmo.d_H / (a**2 * jnp.sqrt(E2(a, cosmo)))
+    cdetada = jnp.concatenate((jnp.array([0, 0]), cdetada))
+    cdeta = (cdetada[:-1] + cdetada[1:]) / 2 * da
+    ceta = jnp.cumsum(cdeta)
+
+    cdtda = cosmo.d_H / (a * jnp.sqrt(E2(a, cosmo)))
+    cdtda = jnp.concatenate((jnp.array([0, 0]), cdtda))
+    cdt = (cdtda[:-1] + cdtda[1:]) / 2 * da
+    ct = jnp.cumsum(cdt)
+
+    distance = jnp.stack((ceta, ct), axis=0)
+
+    #return cosmo.replace(distance=distance)
+    return distance
+
+
+def _SK_closed(chi, Ksqrt):
+    return jnp.sin(Ksqrt * chi) / Ksqrt
+
+def _SK_flat(chi, Ksqrt):
+    return chi
+
+def _SK_open(chi, Ksqrt):
+    return jnp.sinh(Ksqrt * chi) / Ksqrt
+
+
+def distance(a_e, cosmo, type='radial', a_o=1):
+    r"""Interpolate the distances and compute different distance or time measures
+    between emissions and observations.
+
+    Parameters
+    ----------
+    a_e : ArrayLike
+        Scale factors at emission.
+    cosmo : Cosmology
+    type : str in {'radial', 'transverse', 'angdiam', 'luminosity', 'light', 'conformal', 'lookback'}, optional
+        Type of distances or times to return, among radial comoving distance, transverse
+        comoving distance, angular diameter distance, luminosity distance, light-travel
+        distance, conformal time, and lookback time.
+    a_o : ArrayLike, optional
+        Scale factors at observation.
+
+    Returns
+    -------
+    d : jax.Array
+        Distances in :math:`L` or times in :math:`T`.
+
+    Notes
+    -----
+    The line-of-sight or radial comoving distance, related to the conformal time
+    :math:`\eta`
+
+    .. math::
+
+        \chi = c \eta
+             = \int_{t_\mathrm{e}}^{t_\mathrm{o}} \frac{c \mathrm{d} t}{a(t)}
+             = d_H \int_{a_\mathrm{e}}^{a_\mathrm{o}} \frac{\mathrm{d} a'}{a'^2 E(a'}
+             = d_H \int_{z_\mathrm{o}}^{z_\mathrm{e}} \frac{\mathrm{d} z'}{E(z')}.
+
+    The transverse comoving or comoving angular diameter distance
+
+    .. math::
+
+        r = \frac{S_K(\sqrt{|K|} \chi)}{\sqrt{|K|}},
+
+    where :math:`S_K` is sin, identity, or sinh for positive, zero, or negative
+    :math:`K`, respectively.
+
+    The angular diameter distance and luminosity distance
+
+    .. math::
+
+        d_\mathrm{A} &= \frac{a_\mathrm{e}}{a_\mathrm{o}} r, \\
+        d_L &= \frac{a_\mathrm{o}}{a_\mathrm{e}} r.
+
+    The light-travel distance in the lookback or physical time :math:`t`
+
+    .. math::
+
+        ct = \int_{t_\mathrm{e}}^{t_\mathrm{o}} c \mathrm{d} t
+           = d_H \int_{a_\mathrm{e}}^{a_\mathrm{o}} \frac{\mathrm{d} a'}{a' E(a'}
+           = d_H \int_{z_\mathrm{o}}^{z_\mathrm{e}} \frac{\mathrm{d} z'}{(1+z') E(z')}.
+
+    """
+    if cosmo.distance is None:
+        raise ValueError('distance table is empty: run Cosmology.cache or distance_cache first')
+
+    a_e = jnp.asarray(a_e)
+    a_o = jnp.asarray(a_o)
+
+    phys = 1 if type in {'light', 'lookback'} else 0
+    d_o = jnp.interp(a_o, cosmo.distance_a, cosmo.distance[phys])
+    d_e = jnp.interp(a_e, cosmo.distance_a, cosmo.distance[phys])
+    d = d_o - d_e
+
+    if type in {'lookback', 'conformal'}:
+        d /= cosmo.c
+
+    if type in {'radial', 'light', 'lookback', 'conformal'}:
+        return d
+
+    branches = _SK_closed, _SK_flat, _SK_open
+    Ksqrt = jnp.sqrt(jnp.abs(cosmo.K))
+    d = switch(jnp.int8(jnp.sign(cosmo.Omega_K)) + 1, branches, d, Ksqrt)
+    if type == 'transverse':
+        return d
+    if type == 'angdiam':
+        return a_e / a_o * d
+    if type == 'luminosity':
+        return a_o / a_e * d
+
+    raise ValueError(f'{type=} not supported')

--- a/pmwd/background.py
+++ b/pmwd/background.py
@@ -6,7 +6,7 @@ from jax.lax import switch
 
 
 def E2(a, cosmo):
-    """Squared relative Hubble parameter, :math:`E^2`, normalized at :math:`a=1`.
+    r"""Squared relative Hubble parameter, :math:`E^2`, normalized at :math:`a=1`.
 
     Parameters
     ----------
@@ -16,7 +16,7 @@ def E2(a, cosmo):
 
     Returns
     -------
-    E2 : jax.Array of cosmo.Omega_m.dtype
+    E2 : jax.Array of cosmo.dtype
         Squared relative Hubble parameter.
 
     Notes
@@ -35,7 +35,7 @@ def E2(a, cosmo):
                  + \Omega_\mathrm{de} a^{-3 (1 + w_0 + w_a)} e^{-3 w_a (1 - a)}.
 
     """
-    a = jnp.asarray(a, dtype=cosmo.Omega_m.dtype)
+    a = jnp.asarray(a, dtype=cosmo.dtype)
 
     de_a = a**(-3 * (1 + cosmo.w_0 + cosmo.w_a)) * jnp.exp(-3 * cosmo.w_a * (1 - a))
     return cosmo.Omega_m * a**-3 + cosmo.Omega_K * a**-2 + cosmo.Omega_de * de_a
@@ -43,7 +43,7 @@ def E2(a, cosmo):
 
 @partial(jnp.vectorize, excluded=(1,))
 def H_deriv(a, cosmo):
-    """Hubble parameter derivatives, :math:`\mathrm{d}\ln H / \mathrm{d}\ln a`.
+    r"""Hubble parameter derivatives, :math:`\mathrm{d}\ln H / \mathrm{d}\ln a`.
 
     Parameters
     ----------
@@ -53,11 +53,11 @@ def H_deriv(a, cosmo):
 
     Returns
     -------
-    dlnH_dlna : jax.Array of cosmo.Omega_m.dtype
+    dlnH_dlna : jax.Array of cosmo.dtype
         Hubble parameter derivatives.
 
     """
-    a = jnp.asarray(a, dtype=cosmo.Omega_m.dtype)
+    a = jnp.asarray(a, dtype=cosmo.dtype)
 
     E2_value, E2_grad = value_and_grad(E2)(a, cosmo)
     return 0.5 * a * E2_grad / E2_value
@@ -74,7 +74,7 @@ def Omega_m_a(a, cosmo):
 
     Returns
     -------
-    Omega : jax.Array of cosmo.Omega_m.dtype
+    Omega : jax.Array of cosmo.dtype
         Matter density parameters.
 
     Notes
@@ -85,7 +85,7 @@ def Omega_m_a(a, cosmo):
         \Omega_\mathrm{m}(a) = \frac{\Omega_\mathrm{m} a^{-3}}{E^2(a)}
 
     """
-    a = jnp.asarray(a, dtype=cosmo.Omega_m.dtype)
+    a = jnp.asarray(a, dtype=cosmo.dtype)
 
     return cosmo.Omega_m / (a**3 * E2(a, cosmo))
 
@@ -100,8 +100,8 @@ def distance_cache(cosmo):
     Returns
     -------
     cosmo : Cosmology
-        A new instance containing a distance table, in unit :math:`L`, shape
-        ``(2, cosmo.distance_a_num,)``, and precision ``cosmo.Omega_m.dtype``.
+        A new object containing a distance table, in unit :math:`L`, shape ``(2,
+        cosmo.distance_a_num,)``, and precision `cosmo.dtype`.
 
     Notes
     -----

--- a/pmwd/background.py
+++ b/pmwd/background.py
@@ -124,7 +124,7 @@ def distance_cache(cosmo):
     return cT
 
 
-def distance(a, cosmo, type='radial', a_ref=1):
+def distance(a, cosmo, type='radial', time=False, a_ref=1):
     r"""Interpolate and compute different distance or time measures from some events via
     relativistic messengers to some references, e.g., from light emissions to
     observations.
@@ -136,14 +136,14 @@ def distance(a, cosmo, type='radial', a_ref=1):
     cosmo : Cosmology
     type : {'light' or 0, 'radial' or 1, 'transverse', 'angdiam', 'luminosity', 'super'
             or 2, 'coldens' or 3}, optional
-        Type of distances or times to return, among physical/light-travel distance,
-        radial/line-of-sight comoving distance, transverse comoving / comoving angular
+        Type of distances or times to return, among physical / light-travel distance,
+        radial / line-of-sight comoving distance, transverse comoving / comoving angular
         diameter distance, angular diameter distance, luminosity distance, supercomoving
         / superconformal / dispersion measure distance, and that related to
         non-relativistic particle column density.
     time : bool, optional
         Whether to divide by the speed of light to return time measure instead, e.g.,
-        for physical/lookback time with ``type='light'`` or conformal time with
+        for physical / lookback time with ``type='light'`` or conformal time with
         ``type='radial'``. This has no effect on the transverse distances, i.e.,
         'transverse', 'angdiam', and 'luminosity'.
     a_ref : ArrayLike, optional
@@ -201,6 +201,9 @@ def distance(a, cosmo, type='radial', a_ref=1):
             n = 3
         case _:
             raise ValueError(f'{type=} not supported')
+    #TODO left='extrapolate', right='extrapolate' with power-law extrap
+    #TODO for tranfer, growth, distance
+    #TODO a=0 or k=0 case using asinh?
     d = jnp.interp(a, cosmo.distance_a, cosmo.distance[n])
     d_ref = jnp.interp(a_ref, cosmo.distance_a, cosmo.distance[n])
     d -= d_ref
@@ -259,3 +262,25 @@ def _SK_flat(chi, Ksqrt):
 
 def _SK_open(chi, Ksqrt):
     return jnp.sinh(Ksqrt * chi) / Ksqrt
+
+
+#def ang2diam(cosmo, ang, a, type='angdiam'):
+#    """Convert angles to transverse lengths.
+#
+#    Parameters
+#    ----------
+#    cosmo : Cosmology
+#    ang : ArrayLike
+#        Angles in :math:`A`.
+#    a : ArrayLike
+#        Scale factors.
+#    type : {'transverse', 'angdiam', 'luminosity'}, optional
+#        Type of distances. See `distance`.
+#
+#    Returns
+#    -------
+#    diam : jax.Array
+#        Transverse lengths in :math:`L`.
+#
+#    """
+#    return ang * cosmo.A * distance(a, cosmo, type=type)

--- a/pmwd/background.py
+++ b/pmwd/background.py
@@ -99,7 +99,7 @@ def distance_cache(cosmo):
 
     Returns
     -------
-    cT : jax.Array of cosmo.dtype and shape (4, cosmo.distance_a_num,)
+    cT : jax.Array of cosmo.dtype and shape (4, cosmo.distance_a_num)
         Distance table.
 
     Notes
@@ -113,13 +113,13 @@ def distance_cache(cosmo):
     cdTda = cosmo.d_H / (a**(n+1) * jnp.sqrt(E2(a, cosmo)))
     # NOTE approximate c dT/da for n=1
     cdTda = jnp.concatenate(
-        (jnp.array([[0], [0], [jnp.inf], [jnp.inf]], dtype=cosmo.dtype), cdTda))
+        (jnp.array([[0], [0], [jnp.inf], [jnp.inf]], dtype=cosmo.dtype), cdTda), axis=1)
 
     da = jnp.diff(cosmo.distance_a)
-    cdT = (cdTda[:-1] + cdTda[1:]) / 2 * da
-    cdT = jnp.concatenate((cdT, jnp.zero_like(n)))
+    cdT = (cdTda[:, :-1] + cdTda[:, 1:]) / 2 * da
+    cdT = jnp.concatenate((cdT, jnp.zeros_like(n)), axis=1)
 
-    cT = jnp.cumsum(cdT[::-1])[::-1]
+    cT = jnp.cumsum(cdT[:, ::-1], axis=1)[:, ::-1]
 
     return cT
 

--- a/pmwd/background.py
+++ b/pmwd/background.py
@@ -124,6 +124,35 @@ def distance_cache(cosmo):
     return cT
 
 
+def SK(chi, cosmo):
+    r"""Convert radial comoving distances to transverse ones.
+
+    Parameters
+    ----------
+    chi : ArrayLike
+        Radial/line-of-sight comoving distances in :math:`L`.
+    cosmo : Cosmology
+
+    Returns
+    -------
+    r : jax.Array
+        Transverse comoving / comoving angular diameter distances in :math:`L`.
+
+    Notes
+    -----
+    .. math::
+
+        r = \frac{S_K(\sqrt{|K|} \chi)}{\sqrt{|K|}},
+
+    where :math:`K` is `Cosmology.K`, and :math:`S_K` is sine, identity, or hyperbolic
+    sine for positive, zero, or negative :math:`K`, respectively.
+
+    """
+    branches = _SK_closed, _SK_flat, _SK_open
+    Ksqrt = jnp.sqrt(jnp.abs(cosmo.K))
+    r = switch(jnp.int8(jnp.sign(cosmo.Omega_K)) + 1, branches, chi, Ksqrt)
+    return r
+
 def _SK_closed(chi, Ksqrt):
     return jnp.sin(Ksqrt * chi) / Ksqrt
 
@@ -147,14 +176,15 @@ def distance(a, cosmo, type='radial', a_ref=1):
     type : {'light' or 0, 'radial' or 1, 'transverse', 'angdiam', 'luminosity', 'super'
             or 2, 'coldens' or 3}, optional
         Type of distances or times to return, among physical/light-travel distance,
-        radial/line-of-sight comoving distance, transverse comoving distance, angular
-        diameter distance, luminosity distance, supercomoving / superconformal /
-        dispersion measure distance, and that related to non-relativistic particle
-        column density.
+        radial/line-of-sight comoving distance, transverse comoving / comoving angular
+        diameter distance, angular diameter distance, luminosity distance, supercomoving
+        / superconformal / dispersion measure distance, and that related to
+        non-relativistic particle column density.
     time : bool, optional
         Whether to divide by the speed of light to return time measure instead, e.g.,
         for physical/lookback time with ``type='light'`` or conformal time with
-        ``type='radial'``.
+        ``type='radial'``. This has no effect on the transverse distances, i.e.,
+        'transverse', 'angdiam', and 'luminosity'.
     a_ref : ArrayLike, optional
         Scale factors of references.
 
@@ -177,14 +207,8 @@ def distance(a, cosmo, type='radial', a_ref=1):
     related to dispersion measure, and related to non-relativistic particle column
     density, respectively. So :math:`T_0 = t` and :math:`cT_1 = \chi`.
 
-    The transverse comoving or comoving angular diameter distance
-
-    .. math::
-
-        r = \frac{S_K(\sqrt{|K|} \chi)}{\sqrt{|K|}},
-
-    where :math:`S_K` is sine, identity, or hyperbolic sine for positive, zero, or
-    negative :math:`K`, respectively.
+    See `SK` for the transverse comoving or comoving angular diameter distance
+    :math:`r`.
 
     The angular diameter distance and luminosity distance
 
@@ -220,15 +244,12 @@ def distance(a, cosmo, type='radial', a_ref=1):
     d_ref = jnp.interp(a_ref, cosmo.distance_a, cosmo.distance[n])
     d -= d_ref
 
-    if time:
-        d /= cosmo.c
-
     if type in {'light', 'radial', 'super', 'coldens'}:
+        if time:
+            d /= cosmo.c
         return d
 
-    branches = _SK_closed, _SK_flat, _SK_open
-    Ksqrt = jnp.sqrt(jnp.abs(cosmo.K))
-    d = switch(jnp.int8(jnp.sign(cosmo.Omega_K)) + 1, branches, d, Ksqrt)
+    d = SK(d, cosmo)
     if type == 'transverse':
         return d
     if type == 'angdiam':

--- a/pmwd/background.py
+++ b/pmwd/background.py
@@ -124,45 +124,6 @@ def distance_cache(cosmo):
     return cT
 
 
-def SK(chi, cosmo):
-    r"""Convert radial comoving distances to transverse ones.
-
-    Parameters
-    ----------
-    chi : ArrayLike
-        Radial/line-of-sight comoving distances in :math:`L`.
-    cosmo : Cosmology
-
-    Returns
-    -------
-    r : jax.Array
-        Transverse comoving / comoving angular diameter distances in :math:`L`.
-
-    Notes
-    -----
-    .. math::
-
-        r = \frac{S_K(\sqrt{|K|} \chi)}{\sqrt{|K|}},
-
-    where :math:`K` is `Cosmology.K`, and :math:`S_K` is sine, identity, or hyperbolic
-    sine for positive, zero, or negative :math:`K`, respectively.
-
-    """
-    branches = _SK_closed, _SK_flat, _SK_open
-    Ksqrt = jnp.sqrt(jnp.abs(cosmo.K))
-    r = switch(jnp.int8(jnp.sign(cosmo.Omega_K)) + 1, branches, chi, Ksqrt)
-    return r
-
-def _SK_closed(chi, Ksqrt):
-    return jnp.sin(Ksqrt * chi) / Ksqrt
-
-def _SK_flat(chi, Ksqrt):
-    return chi
-
-def _SK_open(chi, Ksqrt):
-    return jnp.sinh(Ksqrt * chi) / Ksqrt
-
-
 def distance(a, cosmo, type='radial', a_ref=1):
     r"""Interpolate and compute different distance or time measures from some events via
     relativistic messengers to some references, e.g., from light emissions to
@@ -259,3 +220,42 @@ def distance(a, cosmo, type='radial', a_ref=1):
         return a_ref / a * d
 
     raise ValueError(f'BUG: {type=} not handled after the above match case')
+
+
+def SK(chi, cosmo):
+    r"""Convert radial comoving distances to transverse ones.
+
+    Parameters
+    ----------
+    chi : ArrayLike
+        Radial/line-of-sight comoving distances in :math:`L`.
+    cosmo : Cosmology
+
+    Returns
+    -------
+    r : jax.Array
+        Transverse comoving / comoving angular diameter distances in :math:`L`.
+
+    Notes
+    -----
+    .. math::
+
+        r = \frac{S_K(\sqrt{|K|} \chi)}{\sqrt{|K|}},
+
+    where :math:`K` is `Cosmology.K`, and :math:`S_K` is sine, identity, or hyperbolic
+    sine for positive, zero, or negative :math:`K`, respectively.
+
+    """
+    branches = _SK_closed, _SK_flat, _SK_open
+    Ksqrt = jnp.sqrt(jnp.abs(cosmo.K))
+    r = switch(jnp.int8(jnp.sign(cosmo.Omega_K)) + 1, branches, chi, Ksqrt)
+    return r
+
+def _SK_closed(chi, Ksqrt):
+    return jnp.sin(Ksqrt * chi) / Ksqrt
+
+def _SK_flat(chi, Ksqrt):
+    return chi
+
+def _SK_open(chi, Ksqrt):
+    return jnp.sinh(Ksqrt * chi) / Ksqrt

--- a/pmwd/background.py
+++ b/pmwd/background.py
@@ -91,7 +91,7 @@ def Omega_m_a(a, cosmo):
 
 
 def distance_cache(cosmo):
-    r"""Cache the comoving and physical distance tables at ``cosmo.distance_a``.
+    r"""Distance tables at ``cosmo.distance_a`` in unit :math:`L`.
 
     Parameters
     ----------
@@ -99,47 +99,29 @@ def distance_cache(cosmo):
 
     Returns
     -------
-    cosmo : Cosmology
-        A new object containing a distance table, in unit :math:`L`, shape ``(2,
-        cosmo.distance_a_num,)``, and precision `cosmo.dtype`.
+    cT : jax.Array of cosmo.dtype and shape (4, cosmo.distance_a_num,)
+        Distance table.
 
     Notes
     -----
-    The comoving horizon in the conformal time :math:`\eta`
-
-    .. math::
-
-        c \eta = \int_0^t \frac{c \mathrm{d} t}{a(t)}
-               = d_H \int_0^a \frac{\mathrm{d} a'}{a'^2 E(a')}
-               = d_H \int_z^\infty \frac{\mathrm{d} z'}{E(z')}.
-
-    The light-travel distance in the age or physical time :math:`t`
-
-    .. math::
-
-        ct = \int_0^t c \mathrm{d} t
-           = d_H \int_0^a \frac{\mathrm{d} a'}{a' E(a')}
-           = d_H \int_z^\infty \frac{\mathrm{d} z'}{(1+z') E(z')}.
+    :math:`cT_n` (see `distance`) relative to the end of ``cosmo.distance_a``.
 
     """
-    #FIXME in the future use jax.scipy.integrate.cumulative_trapezoid or Cubic Hermite spline antiderivatives
-    a = cosmo.distance_a[1:]
-    da = jnp.diff(cosmo.distance_a, prepend=0)
+    #FIXME maybe Cubic Hermite spline antiderivatives in the future
+    a = cosmo.distance_a[1:]  # put aside leading 0
+    n = jnp.arange(4)[:, jnp.newaxis]
+    cdTda = cosmo.d_H / (a**(n+1) * jnp.sqrt(E2(a, cosmo)))
+    # NOTE approximate c dT/da for n=1
+    cdTda = jnp.concatenate(
+        (jnp.array([[0], [0], [jnp.inf], [jnp.inf]], dtype=cosmo.dtype), cdTda))
 
-    cdetada = cosmo.d_H / (a**2 * jnp.sqrt(E2(a, cosmo)))
-    cdetada = jnp.concatenate((jnp.array([0, 0]), cdetada))
-    cdeta = (cdetada[:-1] + cdetada[1:]) / 2 * da
-    ceta = jnp.cumsum(cdeta)
+    da = jnp.diff(cosmo.distance_a)
+    cdT = (cdTda[:-1] + cdTda[1:]) / 2 * da
+    cdT = jnp.concatenate((cdT, jnp.zero_like(n)))
 
-    cdtda = cosmo.d_H / (a * jnp.sqrt(E2(a, cosmo)))
-    cdtda = jnp.concatenate((jnp.array([0, 0]), cdtda))
-    cdt = (cdtda[:-1] + cdtda[1:]) / 2 * da
-    ct = jnp.cumsum(cdt)
+    cT = jnp.cumsum(cdT[::-1])[::-1]
 
-    distance = jnp.stack((ceta, ct), axis=0)
-
-    #return cosmo.replace(distance=distance)
-    return distance
+    return cT
 
 
 def _SK_closed(chi, Ksqrt):
@@ -152,21 +134,29 @@ def _SK_open(chi, Ksqrt):
     return jnp.sinh(Ksqrt * chi) / Ksqrt
 
 
-def distance(a_e, cosmo, type='radial', a_o=1):
-    r"""Interpolate the distances and compute different distance or time measures
-    between emissions and observations.
+def distance(a, cosmo, type='radial', a_ref=1):
+    r"""Interpolate and compute different distance or time measures from some events via
+    relativistic messengers to some references, e.g., from light emissions to
+    observations.
 
     Parameters
     ----------
-    a_e : ArrayLike
-        Scale factors at emission.
+    a : ArrayLike
+        Scale factors of events.
     cosmo : Cosmology
-    type : str in {'radial', 'transverse', 'angdiam', 'luminosity', 'light', 'conformal', 'lookback'}, optional
-        Type of distances or times to return, among radial comoving distance, transverse
-        comoving distance, angular diameter distance, luminosity distance, light-travel
-        distance, conformal time, and lookback time.
-    a_o : ArrayLike, optional
-        Scale factors at observation.
+    type : {'light' or 0, 'radial' or 1, 'transverse', 'angdiam', 'luminosity', 'super'
+            or 2, 'coldens' or 3}, optional
+        Type of distances or times to return, among physical/light-travel distance,
+        radial/line-of-sight comoving distance, transverse comoving distance, angular
+        diameter distance, luminosity distance, supercomoving / superconformal /
+        dispersion measure distance, and that related to non-relativistic particle
+        column density.
+    time : bool, optional
+        Whether to divide by the speed of light to return time measure instead, e.g.,
+        for physical/lookback time with ``type='light'`` or conformal time with
+        ``type='radial'``.
+    a_ref : ArrayLike, optional
+        Scale factors of references.
 
     Returns
     -------
@@ -175,15 +165,17 @@ def distance(a_e, cosmo, type='radial', a_o=1):
 
     Notes
     -----
-    The line-of-sight or radial comoving distance, related to the conformal time
-    :math:`\eta`
-
     .. math::
 
-        \chi = c \eta
-             = \int_{t_\mathrm{e}}^{t_\mathrm{o}} \frac{c \mathrm{d} t}{a(t)}
-             = d_H \int_{a_\mathrm{e}}^{a_\mathrm{o}} \frac{\mathrm{d} a'}{a'^2 E(a'}
-             = d_H \int_{z_\mathrm{o}}^{z_\mathrm{e}} \frac{\mathrm{d} z'}{E(z')}.
+        cT_n(t, t_\mathrm{ref})
+            = \int_t^{t_\mathrm{ref}} \frac{c \mathrm{d} t}{a^n(t)}
+            = d_H \int_a^{a_\mathrm{ref}} \frac{\mathrm{d} a'}{{a'}^{n+1} E(a')}
+            = d_H \int_{z_\mathrm{ref}}^z \frac{(1+z')^{n-1} \mathrm{d} z'}{E(z')},
+
+    which for :math:`n = 0, 1, 2, 3` are physical/light-travel/lookback,
+    (radial/line-of-sight) comoving / conformal, supercomoving / superconformal /
+    related to dispersion measure, and related to non-relativistic particle column
+    density, respectively. So :math:`T_0 = t` and :math:`cT_1 = \chi`.
 
     The transverse comoving or comoving angular diameter distance
 
@@ -191,40 +183,47 @@ def distance(a_e, cosmo, type='radial', a_o=1):
 
         r = \frac{S_K(\sqrt{|K|} \chi)}{\sqrt{|K|}},
 
-    where :math:`S_K` is sin, identity, or sinh for positive, zero, or negative
-    :math:`K`, respectively.
+    where :math:`S_K` is sine, identity, or hyperbolic sine for positive, zero, or
+    negative :math:`K`, respectively.
 
     The angular diameter distance and luminosity distance
 
     .. math::
 
-        d_\mathrm{A} &= \frac{a_\mathrm{e}}{a_\mathrm{o}} r, \\
-        d_L &= \frac{a_\mathrm{o}}{a_\mathrm{e}} r.
+        d_\mathrm{A} &= \frac{a}{a_\mathrm{ref}} r, \\
+        d_\mathrm{L} &= \frac{a_\mathrm{ref}}{a} r,
 
-    The light-travel distance in the lookback or physical time :math:`t`
-
-    .. math::
-
-        ct = \int_{t_\mathrm{e}}^{t_\mathrm{o}} c \mathrm{d} t
-           = d_H \int_{a_\mathrm{e}}^{a_\mathrm{o}} \frac{\mathrm{d} a'}{a' E(a'}
-           = d_H \int_{z_\mathrm{o}}^{z_\mathrm{e}} \frac{\mathrm{d} z'}{(1+z') E(z')}.
+    where :math:`a` and :math:`a_\mathrm{ref}` are for emission and observation,
+    respectively.
 
     """
     if cosmo.distance is None:
-        raise ValueError('distance table is empty: run Cosmology.cache or distance_cache first')
+        raise ValueError('distance table is empty: run Cosmology.cache first')
 
-    a_e = jnp.asarray(a_e)
-    a_o = jnp.asarray(a_o)
+    a = jnp.asarray(a)
+    a_ref = jnp.asarray(a_ref)
 
-    phys = 1 if type in {'light', 'lookback'} else 0
-    d_o = jnp.interp(a_o, cosmo.distance_a, cosmo.distance[phys])
-    d_e = jnp.interp(a_e, cosmo.distance_a, cosmo.distance[phys])
-    d = d_o - d_e
+    match type:
+        case int() if 0 <= type <= 3:
+            n = type
+        case 'light':
+            n = 0
+        case 'radial' | 'transverse' | 'angdiam' | 'luminosity':
+            n = 1
+        case 'super':
+            n = 2
+        case 'coldens':
+            n = 3
+        case _:
+            raise ValueError(f'{type=} not supported')
+    d = jnp.interp(a, cosmo.distance_a, cosmo.distance[n])
+    d_ref = jnp.interp(a_ref, cosmo.distance_a, cosmo.distance[n])
+    d -= d_ref
 
-    if type in {'lookback', 'conformal'}:
+    if time:
         d /= cosmo.c
 
-    if type in {'radial', 'light', 'lookback', 'conformal'}:
+    if type in {'light', 'radial', 'super', 'coldens'}:
         return d
 
     branches = _SK_closed, _SK_flat, _SK_open
@@ -233,8 +232,9 @@ def distance(a_e, cosmo, type='radial', a_o=1):
     if type == 'transverse':
         return d
     if type == 'angdiam':
-        return a_e / a_o * d
+        return a / a_ref * d  # FIXME: keep only `a` following Hogg (& ?),
+                              # FIXME: or find way to reorganize the scale factors?
     if type == 'luminosity':
-        return a_o / a_e * d
+        return a_ref / a * d
 
-    raise ValueError(f'{type=} not supported')
+    raise ValueError(f'BUG: {type=} not handled after the above match case')

--- a/pmwd/boltzmann.py
+++ b/pmwd/boltzmann.py
@@ -324,12 +324,13 @@ def boltz(cosmo, transfer=True, growth=True, varlin=True):
     Parameters
     ----------
     cosmo : Cosmology
-    transfer : bool, optional
-        Whether to compute the transfer function, or to set it to None.
-    growth : bool, optional
-        Whether to compute the growth functions, or to set it to None.
-    varlin : bool, optional
-        Whether to compute the linear matter overdensity variance, or to set it to None.
+    transfer : bool or None, optional
+        Whether to compute the transfer function, leave it as is, or set it to None.
+    growth : bool or None, optional
+        Whether to compute the growth functions, leave it as is, or set it to None.
+    varlin : bool or None, optional
+        Whether to compute the linear matter overdensity variance, leave it as is, or
+        set it to None.
 
     Returns
     -------
@@ -339,17 +340,17 @@ def boltz(cosmo, transfer=True, growth=True, varlin=True):
     """
     if transfer:
         cosmo = transfer_integ(cosmo)
-    else:
+    elif transfer is None:
         cosmo = cosmo.replace(transfer=None)
 
     if growth:
         cosmo = growth_integ(cosmo)
-    else:
+    elif growth is None:
         cosmo = cosmo.replace(growth=None)
 
     if varlin:
         cosmo = varlin_integ(cosmo)
-    else:
+    elif varlin is None:
         cosmo = cosmo.replace(varlin=None)
 
     return cosmo

--- a/pmwd/boltzmann.py
+++ b/pmwd/boltzmann.py
@@ -1,59 +1,58 @@
 from jax import jit, custom_vjp, ensure_compile_time_eval
 import jax.numpy as jnp
 
-from pmwd.cosmology import H_deriv, Omega_m_a
+from pmwd import cosmology
 from pmwd.ode_util import odeint
 
 
 @jit
-def transfer_integ(cosmo, conf):
-    """Compute and tabulate the transfer function at ``conf.transfer_k``.
+def transfer_integ(cosmo):
+    """Compute and tabulate the transfer function at ``cosmo.transfer_k``.
 
     Parameters
     ----------
     cosmo : Cosmology
-    conf : Configuration
 
     Returns
     -------
     cosmo : Cosmology
         A new instance containing a transfer table, that has the shape
-        ``(conf.transfer_k_num,)`` and ``conf.cosmo_dtype``.
+        ``(cosmo.transfer_k_num,)`` and ``cosmo.dtype``.
 
     """
-    if conf.transfer_fit:
-        transfer = transfer_fit(conf.transfer_k, cosmo, conf)
+    if cosmo.transfer_fit:
+        transfer = transfer_fit(cosmo.transfer_k, cosmo)
         return cosmo.replace(transfer=transfer)
-    else:
-        raise NotImplementedError('TODO')
+
+    raise NotImplementedError('TODO')
 
 
 # TODO Wayne's website: neutrino no wiggle case
-def transfer_fit(k, cosmo, conf):
-    """Eisenstein & Hu fit of matter transfer function at given wavenumbers.
+def transfer_fit(k, cosmo):
+    """Eisenstein & Hu fit of matter transfer function.
 
     Parameters
     ----------
     k : ArrayLike
-        Wavenumbers in [1/L].
+        Wavenumbers in :math:`1/L`.
     cosmo : Cosmology
-    conf : Configuration
 
     Returns
     -------
-    T : jax.Array of (k * 1.).dtype
+    T : jax.Array
         Matter transfer function.
 
+    Notes
+    -----
     .. _Transfer Function:
         http://background.uchicago.edu/~whu/transfer/transferpage.html
 
     """
     k = jnp.asarray(k)
-    float_dtype = jnp.promote_types(k.dtype, float)
 
-    k = k * cosmo.h / conf.L * conf.Mpc_SI  # unit conversion to [1/Mpc]
+    k = k * cosmo.h / cosmo.L * cosmo.Mpc_SI  # unit conversion to 1/Mpc
 
-    T2_cmb_norm = (conf.T_cmb / 2.7)**2
+    T2_cmb_norm = (cosmo.T_cmb / 2.7)**2
     h2 = cosmo.h**2
     w_m = cosmo.Omega_m * h2
     w_b = cosmo.Omega_b * h2
@@ -75,7 +74,7 @@ def transfer_fit(k, cosmo, conf):
     )
     k_silk = 1.6 * w_b**0.52 * w_m**0.73 * (1 + (10.4 * w_m)**-0.95)
 
-    if conf.transfer_fit_nowiggle:
+    if cosmo.transfer_fit_nowiggle:
         alpha_gamma = (1 - 0.328 * jnp.log(431 * w_m) * f_b
                        + 0.38 * jnp.log(22.3 * w_m) * f_b**2)
         gamma_eff_ratio = alpha_gamma + (1 - alpha_gamma) / (1 + (0.43 * k * s)**4)
@@ -120,23 +119,21 @@ def transfer_fit(k, cosmo, conf):
 
     T = f_c * T_c + f_b * T_b
 
-    return T.astype(float_dtype)
+    return T
 
 
-def transfer(k, cosmo, conf):
-    """Evaluate interpolation or Eisenstein & Hu fit of matter transfer function at
-    given wavenumbers.
+def transfer(k, cosmo):
+    """Evaluate interpolation of matter transfer function.
 
     Parameters
     ----------
     k : ArrayLike
-        Wavenumbers in [1/L].
+        Wavenumbers in :math:`1/L`.
     cosmo : Cosmology
-    conf : Configuration
 
     Returns
     -------
-    T : jax.Array of (k * 1.).dtype
+    T : jax.Array
         Matter transfer function.
 
     Raises
@@ -146,49 +143,41 @@ def transfer(k, cosmo, conf):
 
     """
     if cosmo.transfer is None:
-        raise ValueError('Transfer table is empty. '
-                         'Call transfer_integ or boltzmann first.')
+        raise ValueError('transfer table is empty: run boltz or transfer_integ first')
 
     k = jnp.asarray(k)
-    float_dtype = jnp.promote_types(k.dtype, float)
 
-    if conf.transfer_fit:
-        T = jnp.interp(k, conf.transfer_k, cosmo.transfer)
-    else:
-        raise NotImplementedError('TODO')
+    T = jnp.interp(k, cosmo.transfer_k, cosmo.transfer)
 
-    return T.astype(float_dtype)
+    return T
 
 
 @jit
-def growth_integ(cosmo, conf):
-    """Integrate and tabulate (LPT) growth functions and derivatives at
-    ``conf.growth_a``.
+def growth_integ(cosmo):
+    r"""Integrate and tabulate (LPT) growth functions and derivatives at
+    ``cosmo.growth_a``.
 
     Parameters
     ----------
     cosmo : Cosmology
-    conf : Configuration
 
     Returns
     -------
     cosmo : Cosmology
         A new instance containing a growth table, that has the shape ``(num_lpt_order,
-        num_derivatives, len(conf.growth_a))`` and ``conf.cosmo_dtype``.
+        num_derivatives, len(cosmo.growth_a))`` and ``cosmo.dtype``.
 
     Notes
     -----
-
     TODO: ODE math
 
     """
-    with ensure_compile_time_eval():
-        eps = jnp.finfo(conf.cosmo_dtype).eps
+    with ensure_compile_time_eval():  # FIXME math.cbrt for python >= 3.11
+        eps = jnp.finfo(cosmo.dtype).eps
         a_ic = 0.5 * jnp.cbrt(eps).item()  # ~ 3e-6 for float64, 2e-3 for float32
-        if a_ic >= conf.a_lpt_step:
-            a_ic = 0.1 * conf.a_lpt_step
+        a_ic = min(a_ic, 0.5 * 10**cosmo.growth_lga_min)
 
-    a = conf.growth_a
+    a = cosmo.growth_a
     lna = jnp.log(a.at[0].set(a_ic))
 
     num_order, num_deriv, num_a = 2, 3, len(a)
@@ -197,17 +186,17 @@ def growth_integ(cosmo, conf):
     # G and lna can either be at a single time, or have leading time axes
     def ode(G, lna, cosmo):
         a = jnp.exp(lna)
-        dlnH_dlna = H_deriv(a, cosmo)
-        Omega_fac = 1.5 * Omega_m_a(a, cosmo)
+        dlnH_dlna = cosmology.H_deriv(a, cosmo)
+        Omega_fac = 1.5 * cosmology.Omega_m_a(a, cosmo)
         G1, G1p, G2, G2p = jnp.split(G, num_order * (num_deriv-1), axis=-1)
         G1pp = -(3 + dlnH_dlna - Omega_fac) * G1 - (4 + dlnH_dlna) * G1p
         G2pp = Omega_fac * G1**2 - (8 + 2*dlnH_dlna - Omega_fac) * G2 - (6 + dlnH_dlna) * G2p
         return jnp.concatenate((G1p, G1pp, G2p, G2pp), axis=-1)
 
-    G_ic = jnp.array((1, 0, 3/7, 0), dtype=conf.cosmo_dtype)
+    G_ic = jnp.array((1, 0, 3/7, 0), dtype=cosmo.dtype)
 
     G = odeint(ode, G_ic, lna, cosmo,
-               rtol=conf.growth_rtol, atol=conf.growth_atol, dt0=conf.growth_inistep)
+               rtol=cosmo.growth_rtol, atol=cosmo.growth_atol, dt0=cosmo.growth_inistep)
 
     G_deriv = ode(G, lna[:, jnp.newaxis], cosmo)
 
@@ -219,7 +208,7 @@ def growth_integ(cosmo, conf):
     # D_m /a^m = G
     # D_m'/a^m = m G + G'
     # D_m"/a^m = m^2 G + 2m G' + G"
-    m = jnp.array((1, 2), dtype=conf.cosmo_dtype)[:, jnp.newaxis]
+    m = jnp.array((1, 2), dtype=cosmo.dtype)[:, jnp.newaxis]
     growth = jnp.stack((
         G[:, 0],
         m * G[:, 0] + G[:, 1],
@@ -230,18 +219,17 @@ def growth_integ(cosmo, conf):
 
 
 # TODO 3rd order has two factors, so `order` probably need to support str
-def growth(a, cosmo, conf, order=1, deriv=0):
-    """Evaluate interpolation of (LPT) growth function or derivative, the n-th
+def growth(a, cosmo, order=1, deriv=0):
+    r"""Evaluate interpolation of (LPT) growth function or derivative, the n-th
     derivatives of the m-th order growth function :math:`\mathrm{d}^n D_m /
-    \mathrm{d}\ln^n a`, at given scale factors. Growth functions are normalized at the
-    matter dominated era instead of today.
+    \mathrm{d}\ln^n a`. Growth functions are normalized at the matter dominated era
+    instead of today.
 
     Parameters
     ----------
     a : ArrayLike
         Scale factors.
     cosmo : Cosmology
-    conf : Configuration
     order : int in {1, 2}, optional
         Order of growth function.
     deriv : int in {0, 1, 2}, optional
@@ -249,7 +237,7 @@ def growth(a, cosmo, conf, order=1, deriv=0):
 
     Returns
     -------
-    D : jax.Array of (a * 1.).dtype
+    D : jax.Array
         Growth functions or derivatives.
 
     Raises
@@ -259,54 +247,51 @@ def growth(a, cosmo, conf, order=1, deriv=0):
 
     """
     if cosmo.growth is None:
-        raise ValueError('Growth table is empty. Call growth_integ or boltzmann first.')
+        raise ValueError('growth table is empty: run boltz or growth_integ first')
 
     a = jnp.asarray(a)
-    float_dtype = jnp.promote_types(a.dtype, float)
 
-    D = a**order * jnp.interp(a, conf.growth_a, cosmo.growth[order-1][deriv])
+    D = a**order * jnp.interp(a, cosmo.growth_a, cosmo.growth[order-1][deriv])
 
-    return D.astype(float_dtype)
+    return D
 
 
-def varlin_integ(cosmo, conf):
-    """Compute and tabulate the linear matter overdensity variance at ``conf.varlin_R``.
+def varlin_integ(cosmo):
+    """Compute and tabulate the linear matter overdensity variance within tophat spheres
+    of ``cosmo.varlin_R`` radii.
 
     Parameters
     ----------
     cosmo : Cosmology
-    conf : Configuration
 
     Returns
     -------
     cosmo : Cosmology
         A new instance containing a linear variance table, that has the shape
-        ``(len(conf.varlin_R),)`` and ``conf.cosmo_dtype``.
+        ``(len(cosmo.varlin_R),)`` and ``cosmo.dtype``.
 
     """
-    Plin = linear_power(conf.var_tophat.x, None, cosmo, conf)
+    Plin = linear_power(cosmo.var_tophat.x, None, cosmo)
 
-    _, varlin = conf.var_tophat(Plin, extrap=True)
+    _, varlin = cosmo.var_tophat(Plin, extrap=True)
 
     return cosmo.replace(varlin=varlin)
 
 
-def varlin(R, a, cosmo, conf):
-    """Evaluate interpolation of linear matter overdensity variance at given scales and
-    scale factors.
+def varlin(R, a, cosmo):
+    """Evaluate interpolation of linear matter overdensity variance.
 
     Parameters
     ----------
     R : ArrayLike
-        Scales in [L].
+        Radii of tophat spheres in :math:`L`.
     a : ArrayLike or None
         Scale factors. If None, output is not scaled by growth.
     cosmo : Cosmology
-    conf : Configuration
 
     Returns
     -------
-    sigma2 : jax.Array of (k * a * 1.).dtype
+    sigma2 : jax.Array
         Linear matter overdensity variance.
 
     Raises
@@ -316,33 +301,29 @@ def varlin(R, a, cosmo, conf):
 
     """
     if cosmo.varlin is None:
-        raise ValueError('Linear matter overdensity variance table is empty. '
-                         'Call varlin_integ or boltzmann first.')
+        raise ValueError('varlin table is empty: run boltz or varlin_integ first')
 
     R = jnp.asarray(R)
-    float_dtype = jnp.promote_types(R.dtype, float)
 
-    sigma2 = jnp.interp(R, conf.varlin_R, cosmo.varlin)
+    sigma2 = jnp.interp(R, cosmo.varlin_R, cosmo.varlin)
 
     if a is not None:
         a = jnp.asarray(a)
-        float_dtype = jnp.promote_types(float_dtype, a.dtype)
 
-        D = growth(a, cosmo, conf)
+        D = growth(a, cosmo)
 
         sigma2 *= D**2
 
-    return sigma2.astype(float_dtype)
+    return sigma2
 
 
-def boltzmann(cosmo, conf, transfer=True, growth=True, varlin=True):
+def boltz(cosmo, transfer=True, growth=True, varlin=True):
     """Solve Einstein-Boltzmann equations and precompute transfer and growth functions,
     etc.
 
     Parameters
     ----------
     cosmo : Cosmology
-    conf : Configuration
     transfer : bool, optional
         Whether to compute the transfer function, or to set it to None.
     growth : bool, optional
@@ -357,17 +338,17 @@ def boltzmann(cosmo, conf, transfer=True, growth=True, varlin=True):
 
     """
     if transfer:
-        cosmo = transfer_integ(cosmo, conf)
+        cosmo = transfer_integ(cosmo)
     else:
         cosmo = cosmo.replace(transfer=None)
 
     if growth:
-        cosmo = growth_integ(cosmo, conf)
+        cosmo = growth_integ(cosmo)
     else:
         cosmo = cosmo.replace(growth=None)
 
     if varlin:
-        cosmo = varlin_integ(cosmo, conf)
+        cosmo = varlin_integ(cosmo)
     else:
         cosmo = cosmo.replace(varlin=None)
 
@@ -396,31 +377,24 @@ def _safe_power_bwd(res, y_cot):
 _safe_power.defvjp(_safe_power_fwd, _safe_power_bwd)
 
 
-def linear_power(k, a, cosmo, conf):
-    r"""Linear matter power spectrum at given wavenumbers and scale factors.
+def linear_power(k, a, cosmo):
+    r"""Linear matter power spectrum.
 
     Parameters
     ----------
     k : ArrayLike
-        Wavenumbers in [1/L].
+        Wavenumbers in :math:`1/L`.
     a : ArrayLike or None
         Scale factors. If None, output is not scaled by growth.
     cosmo : Cosmology
-    conf : Configuration
 
     Returns
     -------
-    Plin : jax.Array of (k * a * 1.).dtype
-        Linear matter power spectrum in [L^3].
-
-    Raises
-    ------
-    ValueError
-        If not in 3D.
+    Plin : jax.Array
+        Linear matter power spectrum in :math:`L^3`.
 
     Notes
     -----
-
     .. math::
 
         \frac{k^3}{2\pi^2} P_\mathrm{lin}(k, a)
@@ -431,25 +405,20 @@ def linear_power(k, a, cosmo, conf):
             \Bigl( \frac{D(a)}{\Omega_\mathrm{m}} \Bigr)^2
 
     """
-    if conf.dim != 3:
-        raise ValueError(f'dim={conf.dim} not supported')
-
     k = jnp.asarray(k)
-    float_dtype = jnp.promote_types(k.dtype, float)
 
-    T = transfer(k, cosmo, conf)
+    T = transfer(k, cosmo)
 
     Plin = (
         0.32 * cosmo.A_s * cosmo.k_pivot * _safe_power(k / cosmo.k_pivot, cosmo.n_s)
-        * (jnp.pi * (conf.c / conf.H_0)**2 / cosmo.Omega_m * T)**2
+        * (jnp.pi * (cosmo.c / cosmo.H_0)**2 / cosmo.Omega_m * T)**2
     )
 
     if a is not None:
         a = jnp.asarray(a)
-        float_dtype = jnp.promote_types(float_dtype, a.dtype)
 
-        D = growth(a, cosmo, conf)
+        D = growth(a, cosmo)
 
         Plin *= D**2
 
-    return Plin.astype(float_dtype)
+    return Plin

--- a/pmwd/constants.py
+++ b/pmwd/constants.py
@@ -1,7 +1,12 @@
-from jax.typing import ArrayLike
+from jax.typing import ArrayLike  # FIXME float okay or need to be ArrayLike?
 import jax.numpy as jnp
 
 from pmwd.tree_util import Tree, pytree_dataclass, fxd_field
+
+
+#NOTE I tried moving M, L, T here
+# pro: all unit and const conversion can be put at the same place
+# con: seems too complicated to keep 2 sets of every constants in one place
 
 
 @pytree_dataclass
@@ -16,10 +21,18 @@ class Constants(Tree):
         Gravitational constant :math:`G` in m:math:`^3`/kg/s:math:`^2`
     hbar : float ArrayLike, optional
         Reduced Planck constant :math:`\hbar` in J:math:`\cdot`s.
-    e : float ArrayLike, optional
-        Elementary charge :math:`e` in C.
     k : float ArrayLike, optional
         Boltzmann constant :math:`k` in J/K.
+    e : float ArrayLike, optional
+        Elementary charge :math:`e` in C.
+    N_A : float ArrayLike, optional
+        Avogadro constant in mol:math:`^-1`.
+    u : float ArrayLike, optional
+        Unified atomic mass unit, or Dalton, in kg.
+    m_p : float ArrayLike, optional
+        Proton mass in kg.
+    m_e : float ArrayLike, optional
+        Electron mass in kg.
     M_sun : float ArrayLike, optional
         Solar mass :math:`M_\odot` in kg.
     Mpc : float ArrayLike, optional
@@ -32,8 +45,14 @@ class Constants(Tree):
     c: ArrayLike = fxd_field(default=2.99792458e8, repr=True)  # exact
     G: ArrayLike = fxd_field(default=6.67430e-11, repr=True)
     hbar: ArrayLike = fxd_field(default=6.62607015e-34 / (2*jnp.pi), repr=True)  # exact
-    e: ArrayLike = fxd_field(default=1.602176634e-19, repr=True)  # exact
     k: ArrayLike = fxd_field(default=1.380649e-23, repr=True)  # exact
+    e: ArrayLike = fxd_field(default=1.602176634e-19, repr=True)  # exact
+    N_A: ArrayLike = fxd_field(default=6.02214076e23, repr=True)  # exact
+
+    u: ArrayLike = fxd_field(default=1.66053906892e-27, repr=True)
+    m_p: ArrayLike = fxd_field(depend=lambda self: 1.0072764665789 * self.u, repr=True)
+    m_e: ArrayLike = fxd_field(depend=lambda self: 5.485799090441e-4 * self.u,
+                               repr=True)
 
     M_sun: ArrayLike = fxd_field(default=1.98847e30, repr=True)
     Mpc: ArrayLike = fxd_field(default=3.0856775815e22, repr=True)

--- a/pmwd/constants.py
+++ b/pmwd/constants.py
@@ -1,0 +1,40 @@
+from jax.typing import ArrayLike
+import jax.numpy as jnp
+
+from pmwd.tree_util import Tree, pytree_dataclass, fxd_field
+
+
+@pytree_dataclass
+class Constants(Tree):
+    r"""Physical constants in SI units, some are exact.
+
+    Parameters
+    ----------
+    c : float ArrayLike, optional
+        Speed of light :math:`c` in m/s.
+    G : float ArrayLike, optional
+        Gravitational constant :math:`G` in m:math:`^3`/kg/s:math:`^2`
+    hbar : float ArrayLike, optional
+        Reduced Planck constant :math:`\hbar` in J:math:`\cdot`s.
+    e : float ArrayLike, optional
+        Elementary charge :math:`e` in C.
+    k : float ArrayLike, optional
+        Boltzmann constant :math:`k` in J/K.
+    M_sun : float ArrayLike, optional
+        Solar mass :math:`M_\odot` in kg.
+    Mpc : float ArrayLike, optional
+        Mpc in m.
+    H_0 : float ArrayLike, optional
+        Hubble constant :math:`H_0` in :math:`h`/s.
+
+    """
+
+    c: ArrayLike = fxd_field(default=2.99792458e8, repr=True)  # exact
+    G: ArrayLike = fxd_field(default=6.67430e-11, repr=True)
+    hbar: ArrayLike = fxd_field(default=6.62607015e-34 / (2*jnp.pi), repr=True)  # exact
+    e: ArrayLike = fxd_field(default=1.602176634e-19, repr=True)  # exact
+    k: ArrayLike = fxd_field(default=1.380649e-23, repr=True)  # exact
+
+    M_sun: ArrayLike = fxd_field(default=1.98847e30, repr=True)
+    Mpc: ArrayLike = fxd_field(default=3.0856775815e22, repr=True)
+    H_0: ArrayLike = fxd_field(depend=lambda self: 1e5 / self.Mpc, repr=True)

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -112,8 +112,9 @@ class Cosmology:
     L : float
         Length unit :math:`L` defined in m/:math:`h`. Default is Mpc/:math:`h`.
     T : float
-        Time unit :math:`T` defined in s/:math:`h`. Default is Hubble time :math:`1/H_0 \sim
-        10^{10}` years/:math:`h \sim` age of the Universe.
+        Time unit :math:`T` defined in s/:math:`h`. Default is Hubble time :math:`1/H_0
+        \sim 10^{10}` years/:math:`h \sim` age of the Universe. So the default velocity
+        unit is :math:`L/T =` 100 km/s.
     k_pivot_Mpc : float
         Primordial scalar power spectrum pivot scale :math:`k_\mathrm{pivot}` in 1/Mpc.
 
@@ -270,11 +271,6 @@ class Cosmology:
         return jnp.sqrt(boltzmann.varlin(R, 1, self))
 
     @property
-    def V(self):
-        r"""Velocity unit :math:`V \triangleq L/T`. Default is 100 km/s."""
-        return self.L / self.T
-
-    @property
     def H_0(self):
         """Hubble constant :math:`H_0` in :math:`1/T`."""
         return self.H_0_SI * self.T
@@ -282,12 +278,12 @@ class Cosmology:
     @property
     def c(self):
         """Speed of light :math:`c` in :math:`L/T`."""
-        return self.c_SI / self.V
+        return self.c_SI * self.T / self.L
 
     @property
     def G(self):
         """Gravitational constant :math:`G` in :math:`L^3 / M / T^2`."""
-        return self.G_SI * self.M / (self.L * self.V**2)
+        return self.G_SI * self.M * self.T**2 / self.L**3
 
     @property
     def rho_crit(self):

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -601,11 +601,11 @@ def distance(a_e, cosmo, type='radial', a_o=1):
     a_e : ArrayLike
         Scale factors at emission.
     cosmo : Cosmology
-    type : str in {'radial', 'transverse', 'angdiam', 'luminosity', 'light', 'conformal', 'lookback'}
+    type : str in {'radial', 'transverse', 'angdiam', 'luminosity', 'light', 'conformal', 'lookback'}, optional
         Type of distances or times to return, among radial comoving distance, transverse
         comoving distance, angular diameter distance, luminosity distance, light-travel
         distance, conformal time, and lookback time.
-    a_o : ArrayLike
+    a_o : ArrayLike, optional
         Scale factors at observation.
 
     Returns

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -332,12 +332,12 @@ class Cosmology:
 
     @property
     def Omega_K(self):
-        r"""Spatial curvature density parameter today :math:`\Omega_K`."""
+        r"""Spatial curvature density parameter today :math:`\Omega_K = - K d_H^2`."""
         return self.Omega_K_fixed if self.Omega_K_ is None else self.Omega_K_
 
     @property
     def K(self):
-        r"""Spatial Gaussian curvature :math:`K = - \Omega_K / d_H^2` in :math:`1/L^2`."""
+        r"""Spatial Gaussian curvature :math:`K` in :math:`1/L^2`."""
         return - self.Omega_K / self.d_H**2
 
     @property

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -214,11 +214,49 @@ class Cosmology:
     def from_sigma8(cls, sigma8, *args, **kwargs):
         r"""Construct cosmology with :math:`\sigma_8` instead of :math:`A_s`."""
         cosmo = cls(1, *args, **kwargs)
-        cosmo = boltzmann.boltz(cosmo)
+        cosmo = cosmo.prime()  #FIXME set distance=False
 
         A_s_1e9 = (sigma8 / cosmo.sigma8)**2
 
         return cls(A_s_1e9, *args, **kwargs)
+
+    def prime(self, transfer=True, growth=True, varlin=True):
+        """Tabulate and cache the transfer and growth functions, etc.
+
+        Parameters
+        ----------
+        transfer : bool or None, optional
+            Whether to compute the transfer function, leave it as is, or set it to None.
+        growth : bool or None, optional
+            Whether to compute the growth functions, leave it as is, or set it to None.
+        varlin : bool or None, optional
+            Whether to compute the linear matter overdensity variance, leave it as is,
+            or set it to None.
+
+        Returns
+        -------
+        cosmo : Cosmology
+            A new instance containing transfer and growth tables, etc.
+
+        """
+        cosmo = self
+
+        if transfer:
+            cosmo = boltzmann.transfer_tab(cosmo)
+        elif transfer is None:
+            cosmo = cosmo.replace(transfer=None)
+
+        if growth:
+            cosmo = boltzmann.growth_tab(cosmo)
+        elif growth is None:
+            cosmo = cosmo.replace(growth=None)
+
+        if varlin:
+            cosmo = boltzmann.varlin_tab(cosmo)
+        elif varlin is None:
+            cosmo = cosmo.replace(varlin=None)
+
+        return cosmo
 
     def astype(self, dtype):
         """Cast parameters to dtype."""

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -129,24 +129,6 @@ class Cosmology:
 
     """
 
-    # TODO keyword-only for python>=3.10
-
-    A_s_1e9: ArrayLike
-    n_s: ArrayLike
-    Omega_m: ArrayLike
-    Omega_b: ArrayLike
-    h: ArrayLike
-
-    T_cmb_: Optional[ArrayLike] = None
-    T_cmb_fixed: ClassVar[float] = 2.7255  # Fixsen 2009, arXiv:0911.1955
-
-    Omega_K_: Optional[ArrayLike] = None
-    Omega_K_fixed: ClassVar[float] = 0
-    w_0_: Optional[ArrayLike] = None
-    w_0_fixed: ClassVar[float] = -1
-    w_a_: Optional[ArrayLike] = None
-    w_a_fixed: ClassVar[float] = 0
-
     # constants in SI units
     M_sun_SI: ClassVar[float] = 1.98847e30
     Mpc_SI: ClassVar[float] = 3.0856775815e22
@@ -159,6 +141,26 @@ class Cosmology:
     L: ClassVar[float] = Mpc_SI
     T: ClassVar[float] = 1 / H_0_SI
 
+    # TODO keyword-only for python>=3.10
+
+    # free parameters
+    A_s_1e9: ArrayLike
+    n_s: ArrayLike
+    Omega_m: ArrayLike
+    Omega_b: ArrayLike
+    h: ArrayLike
+
+    # optionally free parameters
+    T_cmb_: Optional[ArrayLike] = None
+    T_cmb_fixed: ClassVar[float] = 2.7255  # Fixsen 2009, arXiv:0911.1955
+    Omega_K_: Optional[ArrayLike] = None
+    Omega_K_fixed: ClassVar[float] = 0
+    w_0_: Optional[ArrayLike] = None
+    w_0_fixed: ClassVar[float] = -1
+    w_a_: Optional[ArrayLike] = None
+    w_a_fixed: ClassVar[float] = 0
+
+    # fixed parameters
     k_pivot_Mpc: ClassVar[float] = 0.05
 
     distance_lga_min: float = -3

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -623,12 +623,7 @@ def distance(a_e, cosmo, type='radial', a_o=1):
     if cosmo.distance is None:
         raise ValueError('distance table is empty: run Cosmology.prime or distance_tab first')
 
-    if a_e is None:
-        a_e = 0
     a_e = jnp.asarray(a_e)
-
-    if a_o is None:
-        a_o = 1
     a_o = jnp.asarray(a_o)
 
     d_o = jnp.interp(a_o, cosmo.distance_a, cosmo.distance)

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -209,9 +209,9 @@ class Cosmology:
         if not jnp.issubdtype(self.dtype, jnp.floating):
             raise ValueError('dtype must be floating point numbers')
 
-        for name, value in chain(self.named_dyn_data(), self.named_opt_data()):
+        for key, value in chain(self.dyn_data_with_keys(), self.opt_data_with_keys()):
             value = tree_map(partial(jnp.asarray, dtype=self.dtype), value)
-            object.__setattr__(self, name, value)
+            object.__setattr__(self, key.name, value)
 
         with ensure_compile_time_eval():
             object.__setattr__(

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -1,24 +1,22 @@
 from functools import partial
 import math
-#FIXME can use tuple now?
-#FIXME Union shorthand is ?
-from typing import Optional, Tuple, Union
 
 from jax import Array, ensure_compile_time_eval
 from jax.typing import ArrayLike, DTypeLike
 import jax.numpy as jnp
 from mcfit import mcfit, TophatVar
 
-from pmwd import perturbation
-from pmwd.tree_util import DataTree, pytree_dataclass, dyn_field, fxd_field, aux_field, asarray_of  # FIXME asarray_of to tree.py, as in JAX?
-from pmwd.background import distance_cache
-from pmwd.perturbation import transfer_cache, growth_cache, varlin_cache
+from pmwd import background, perturbation
+from pmwd.tree_util import DataTree, pytree_dataclass, dyn_field, fxd_field, aux_field, issubdtype_of, asarray_of
 
 
-cosmo_dyn_field = partial(dyn_field, validate=asarray_of())
-cosmo_dyn_field.__doc__ = 'Like ``dyn_field`` with default dtype.'
-cosmo_fxd_field = partial(fxd_field, validate=asarray_of())
-cosmo_fxd_field.__doc__ = 'Like ``fxd_field`` with default dtype.'
+cosmo_dyn_field = partial(dyn_field, validate=asarray_of(field='dtype'))
+cosmo_dyn_field.__doc__ = 'Like `tree_util.dyn_field` with `Cosmology.dtype` casting.'
+cosmo_fxd_field = partial(fxd_field, validate=asarray_of(field='dtype'))
+cosmo_fxd_field.__doc__ = 'Like `tree_util.fxd_field` with `Cosmology.dtype` casting.'
+
+
+# FIXME is float32 enough for cosmology? especially parameter gradients?
 
 
 def _eps2tol(dtype):
@@ -33,31 +31,12 @@ def _init_var_tophat(self):
 
 @pytree_dataclass
 class Cosmology(DataTree):
-    r"""Cosmological parameters and relevant configurations.
-
-    #Fields marked by ``aux_field`` are auxiliary data (see
-    #``tree_util.pytree_dataclass``), and the other fields
-
-    #Parameters with one trailing underscore, e.g.,  ``foo_``, are optional as extensions
-    #to the dynamic free parameters without trailing underscores. They are None and
-    #deactivated by default, taking the fixed values set by variable ``foo__`` (see
-    #below). They should be accessed through corresponding properties named without the
-    #trailing underscores, i.e., ``foo``.
-
-    #Parameters marked by ``fxd_field`` are fixed and do not receive gradients, including
-    #physical constants and units.
-
-    #They should be accessed through corresponding properties named without the trailing
-    #underscores, i.e., ``foo``.
-
-    #Linear operators (addition, subtraction, and scalar multiplication) are defined for
-    #Cosmology tangent and cotangent vectors.
-
-    #Parameters are converted to JAX arrays at instantiation, for ``dtype`` casting and
-    #to avoid possible JAX weak type problems.
+    r"""Cosmological parameters and configurations.
 
     Parameters
     ----------
+    dtype : DTypeLike, optional
+        Parameter float dtype.
     A_s_1e9 : float ArrayLike
         Primordial scalar power spectrum amplitude :math:`A_\mathrm{s} \times 10^9`.
     n_s : float ArrayLike
@@ -103,8 +82,8 @@ class Cosmology(DataTree):
         Maximum distance scale factor in log10.
     distance_lga_maxstep : float, optional
         Maximum distance scale factor step size in log10. It determines the number of
-        scale factors ``distance_a_num``, the actual step size ``distance_lga_step``,
-        and the scale factors ``distance_a``.
+        scale factors `distance_a_num`, the actual step size `distance_lga_step`, and
+        the scale factors `distance_a`.
     #FIXME use transfer_function: Callable = aux_field(...) instead
     #transfer_fit : bool, optional
     #    Whether to use Eisenstein & Hu fit to transfer function. Default is True
@@ -117,15 +96,15 @@ class Cosmology(DataTree):
         Maximum transfer function wavenumber in :math:`1/L` in log10.
     transfer_lgk_maxstep : float, optional
         Maximum transfer function wavenumber step size in :math:`1/L` in log10. It
-        determines the number of wavenumbers ``transfer_k_num``, the actual step size
-        ``transfer_lgk_step``, and the wavenumbers ``transfer_k``.
+        determines the number of wavenumbers `transfer_k_num`, the actual step size
+        `transfer_lgk_step`, and the wavenumbers `transfer_k`.
     growth_rtol : float, optional
-        Relative tolerance for solving the growth ODEs. Default is sqrt of
-        ``Omega_m.dtype`` epsilon, i.e., :math:`1.5 \times 10^{-8}` for float64 and
+        Relative tolerance for solving the growth ODEs. Default is sqrt of `dtype`
+        `jax.numpy.finfo.eps`, i.e., :math:`1.5 \times 10^{-8}` for float64 and
         :math:`3.5 \times 10^{-4}` for float32.
     growth_atol : float, optional
-        Absolute tolerance for solving the growth ODEs. Default is sqrt of
-        ``Omega_m.dtype`` epsilon, i.e., :math:`1.5 \times 10^{-8}` for float64 and
+        Absolute tolerance for solving the growth ODEs. Default is sqrt of `dtype`
+        `jax.numpy.finfo.eps`, i.e., :math:`1.5 \times 10^{-8}` for float64 and
         :math:`3.5 \times 10^{-4}` for float32.
     growth_inistep: float, None, or 2-tuple of them, optional
         The initial step size for solving the growth ODEs. If None, use estimation. If a
@@ -137,14 +116,15 @@ class Cosmology(DataTree):
         Maximum growth function scale factor in log10.
     growth_lga_maxstep : float, optional
         Maximum growth function scale factor step size in log10. It determines the
-        number of scale factors ``growth_a_num``, the actual step size
-        ``growth_lga_step``, and the scale factors ``growth_a``.
-    #dtype : DTypeLike, optional
-    #    Parameter float dtype.
+        number of scale factors `growth_a_num`, the actual step size `growth_lga_step`,
+        and the scale factors `growth_a`.
 
     """
 
     # TODO keyword-only for python>=3.10
+
+    dtype: DTypeLike = aux_field(default=float,
+                                 validate=(jnp.dtype, issubdtype_of(jnp.floating)))
 
     A_s_1e9: ArrayLike = cosmo_dyn_field()
     n_s: ArrayLike = cosmo_dyn_field()
@@ -153,19 +133,19 @@ class Cosmology(DataTree):
     h: ArrayLike = cosmo_dyn_field()
 
     T_cmb: ArrayLike = cosmo_fxd_field(default=2.7255)  # Fixsen 2009, arXiv:0911.1955
-    Omega_K: ArrayLike = cosmo_fxd_field(default=0.)
-    w_0: ArrayLike = cosmo_fxd_field(default=-1.)
-    w_a: ArrayLike = cosmo_fxd_field(default=0.)
+    Omega_K: ArrayLike = cosmo_fxd_field(default=0)
+    w_0: ArrayLike = cosmo_fxd_field(default=-1)
+    w_a: ArrayLike = cosmo_fxd_field(default=0)
     k_pivot_Mpc: ArrayLike = cosmo_fxd_field(default=0.05)
 
     # constants in SI units
     M_sun_SI: ArrayLike = cosmo_fxd_field(default=1.98847e30)
     Mpc_SI: ArrayLike = cosmo_fxd_field(default=3.0856775815e22)
     H_0_SI: ArrayLike = cosmo_fxd_field(default_function=lambda self: 1e5 / self.Mpc_SI)
-    c_SI: ArrayLike = cosmo_fxd_field(default=299792458.)
+    c_SI: ArrayLike = cosmo_fxd_field(default=299792458)
     G_SI: ArrayLike = cosmo_fxd_field(default=6.67430e-11)
 
-    # units
+    # units in SI units
     M: ArrayLike = cosmo_fxd_field(default_function=lambda self: 1e10 * self.M_sun_SI)
     L: ArrayLike = cosmo_fxd_field(default_function=lambda self: self.Mpc_SI)
     T: ArrayLike = cosmo_fxd_field(default_function=lambda self: 1 / self.H_0_SI)
@@ -173,66 +153,32 @@ class Cosmology(DataTree):
     distance_lga_min: float = aux_field(default=-3)
     distance_lga_max: float = aux_field(default=1)
     distance_lga_maxstep: float = aux_field(default=1/128)
-    distance: Optional[Array] = cosmo_dyn_field(cache=distance_cache, compare=False)
-    # FIXME | None is shorter than Optional
+    distance: Array | None = cosmo_dyn_field(cache=background.distance_cache,
+                                             compare=False)
 
     transfer_fit: bool = aux_field(default=True)
     transfer_fit_nowiggle: bool = aux_field(default=False)
     transfer_lgk_min: float = aux_field(default=-4)
     transfer_lgk_max: float = aux_field(default=3)
     transfer_lgk_maxstep: float = aux_field(default=1/128)
-    transfer: Optional[Array] = cosmo_dyn_field(cache=transfer_cache, compare=False)
+    transfer: Array | None = cosmo_dyn_field(cache=perturbation.transfer_cache,
+                                             compare=False)
 
-    growth_rtol: Optional[float] = aux_field(
-        default_function=lambda self: _eps2tol(self.Omega_m.dtype))
-    growth_atol: Optional[float] = aux_field(
-        default_function=lambda self: _eps2tol(self.Omega_m.dtype))
-    growth_inistep: Union[float, None,
-                          Tuple[Optional[float],
-                                Optional[float]]] = aux_field(default=(1, 1))  # (1, None) used to work? but now also causes nan in sigma_8 gradients
+    growth_rtol: float = aux_field(default_function=lambda self: _eps2tol(self.dtype))
+    growth_atol: float = aux_field(default_function=lambda self: _eps2tol(self.dtype))
+    growth_inistep: (float | None
+                     | tuple[float|None, float|None]) = aux_field(default=(1, 1))  # FIXME (1, None) used to work? but now also causes nan in sigma_8 gradients
     growth_lga_min: float = aux_field(default=-3)
     growth_lga_max: float = aux_field(default=1)
     growth_lga_maxstep: float = aux_field(default=1/128)
-    growth: Optional[Array] = cosmo_dyn_field(cache=growth_cache, compare=False)
+    growth: Array | None = cosmo_dyn_field(cache=perturbation.growth_cache,
+                                           compare=False)
 
-    varlin: Optional[Array] = cosmo_dyn_field(cache=varlin_cache, compare=False)
+    varlin: Array | None = cosmo_dyn_field(cache=perturbation.varlin_cache,
+                                           compare=False)
 
     #FIXME although mcfit.mcfit is hashable but maybe this can be more functional
     _var_tophat: mcfit = aux_field(default_function=_init_var_tophat)
-
-    #dtype: DTypeLike = aux_field(default=jnp.float64)
-
-    #def __post_init__(self):
-    #    if self._is_transforming():
-    #        return
-
-    #    object.__setattr__(self, 'dtype', jnp.dtype(self.dtype))
-    #    if not jnp.issubdtype(self.dtype, jnp.floating):
-    #        raise ValueError('dtype must be floating point numbers')
-
-    #    if self.H_0_SI is None:
-    #        object.__setattr__(self, 'H_0_SI', 1e5 / self.Mpc_SI)
-    #    if self.M is None:
-    #        object.__setattr__(self, 'M', 1e10 * self.M_sun_SI)
-    #    if self.T is None:
-    #        object.__setattr__(self, 'T', 1 / self.H_0_SI)
-
-    #    for key, value in self.dyn_data_with_keys():
-    #        value = tree_map(partial(jnp.asarray, dtype=self.dtype), value)
-    #        object.__setattr__(self, key.name, value)
-
-    #    with ensure_compile_time_eval():
-    #        object.__setattr__(
-    #            self,
-    #            'var_tophat',
-    #            TophatVar(self.transfer_k[1:], lowring=True, backend='jax'),
-    #        )
-
-    #    growth_tol = math.sqrt(jnp.finfo(self.dtype).eps)
-    #    if self.growth_rtol is None:
-    #        object.__setattr__(self, 'growth_rtol', growth_tol)
-    #    if self.growth_atol is None:
-    #        object.__setattr__(self, 'growth_atol', growth_tol)
 
     @classmethod
     def from_sigma_8(cls, sigma_8, *args, **kwargs):
@@ -244,60 +190,9 @@ class Cosmology(DataTree):
 
         return cls(A_s_1e9, *args, **kwargs)
 
-    #def cache(self, distance=True, transfer=True, growth=True, varlin=True):
-    #    """Cache distance, transfer, growth, and linear variance tables.
-
-    #    Parameters
-    #    ----------
-    #    distance : bool or None, optional
-    #        Whether to cache the distances, leave it as is, or set it to None.
-    #    transfer : bool or None, optional
-    #        Whether to cache the transfer function, leave it as is, or set it to None,
-    #        overridden if ``varlin=True``.
-    #    growth : bool or None, optional
-    #        Whether to cache the growth functions, leave it as is, or set it to None,
-    #        overridden if ``varlin=True``.
-    #    varlin : bool or None, optional
-    #        Whether to cache the linear matter overdensity variance, leave it as is,
-    #        or set it to None.
-
-    #    Returns
-    #    -------
-    #    cosmo : Cosmology
-    #        A new instance containing cached tables.
-
-    #    """
-    #    cosmo = self
-
-    #    if distance:
-    #        #cosmo = distance_cache(cosmo)
-    #        cosmo = cosmo.replace(distance=distance_cache(cosmo))
-    #    elif distance is None:
-    #        cosmo = cosmo.replace(distance=None)
-
-    #    if transfer or varlin:
-    #        #cosmo = boltzmann.transfer_cache(cosmo)
-    #        cosmo = cosmo.replace(transfer=boltzmann.transfer_cache(cosmo))
-    #    elif transfer is None:
-    #        cosmo = cosmo.replace(transfer=None)
-
-    #    if growth or varlin:
-    #        #cosmo = boltzmann.growth_cache(cosmo)
-    #        cosmo = cosmo.replace(growth=boltzmann.growth_cache(cosmo))
-    #    elif growth is None:
-    #        cosmo = cosmo.replace(growth=None)
-
-    #    if varlin:
-    #        #cosmo = boltzmann.varlin_cache(cosmo)
-    #        cosmo = cosmo.replace(varlin=boltzmann.varlin_cache(cosmo))
-    #    elif varlin is None:
-    #        cosmo = cosmo.replace(varlin=None)
-
-    #    return cosmo
-
-    #def astype(self, dtype):
-    #    """Cast parameters to dtype."""
-    #    return self.replace(dtype=dtype)  # calls __init__ and then __post_init__
+    def astype(self, dtype):
+        """Return a new object with pytree children casted to `dtype`."""
+        return self.replace(dtype=dtype)
 
     @property
     def H_0(self):
@@ -371,7 +266,7 @@ class Cosmology(DataTree):
     def distance_a(self):
         """Distance scale factors."""
         a = jnp.logspace(self.distance_lga_min, self.distance_lga_max,
-                         num=self.distance_a_num - 1, dtype=self.Omega_m.dtype)
+                         num=self.distance_a_num - 1, dtype=self.dtype)
         return jnp.concatenate((jnp.array([0]), a))
 
     @property
@@ -390,7 +285,7 @@ class Cosmology(DataTree):
     def transfer_k(self):
         """Transfer function wavenumbers in :math:`1/L`."""
         k = jnp.logspace(self.transfer_lgk_min, self.transfer_lgk_max,
-                         num=self.transfer_k_num - 1, dtype=self.Omega_m.dtype)
+                         num=self.transfer_k_num - 1, dtype=self.dtype)
         return jnp.concatenate((jnp.array([0]), k))
 
     @property
@@ -409,13 +304,13 @@ class Cosmology(DataTree):
     def growth_a(self):
         """Growth function scale factors."""
         a = jnp.logspace(self.growth_lga_min, self.growth_lga_max,
-                         num=self.growth_a_num - 1, dtype=self.Omega_m.dtype)
+                         num=self.growth_a_num - 1, dtype=self.dtype)
         return jnp.concatenate((jnp.array([0]), a))
 
     @property
     def varlin_R(self):
         """Radii of tophat spheres in :math:`L` for linear matter overdensity variance,
-        determined by ``transfer_k`` and the FFTLog algorithm."""
+        determined by `transfer_k` and the FFTLog algorithm."""
         return self._var_tophat.y
 
 

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -7,13 +7,13 @@ import jax.numpy as jnp
 from mcfit import mcfit, TophatVar
 
 from pmwd import background, perturbation
-from pmwd.tree_util import DataTree, pytree_dataclass, dyn_field, fxd_field, aux_field, issubdtype_of, asarray_of
+from pmwd.tree_util import Tree, TanMixin, pytree_dataclass, dyn_field, fxd_field, aux_field, issubdtype_of, asarray_of
 
 
 cosmo_dyn_field = partial(dyn_field, validate=asarray_of(field='dtype'))
-cosmo_dyn_field.__doc__ = 'Like `tree_util.dyn_field` with `Cosmology.dtype` casting.'
+cosmo_dyn_field.__doc__ = '`tree_util.dyn_field` with `Cosmology.dtype` casting.'
 cosmo_fxd_field = partial(fxd_field, validate=asarray_of(field='dtype'))
-cosmo_fxd_field.__doc__ = 'Like `tree_util.fxd_field` with `Cosmology.dtype` casting.'
+cosmo_fxd_field.__doc__ = '`tree_util.fxd_field` with `Cosmology.dtype` casting.'
 
 
 # FIXME is float32 enough for cosmology? especially parameter gradients?
@@ -30,7 +30,7 @@ def _init_var_tophat(self):
 
 
 @pytree_dataclass
-class Cosmology(DataTree):
+class Cosmology(TanMixin, Tree):
     r"""Cosmological parameters and configurations.
 
     Parameters
@@ -132,23 +132,23 @@ class Cosmology(DataTree):
     Omega_b: ArrayLike = cosmo_dyn_field()
     h: ArrayLike = cosmo_dyn_field()
 
-    T_cmb: ArrayLike = cosmo_fxd_field(default=2.7255)  # Fixsen 2009, arXiv:0911.1955
-    Omega_K: ArrayLike = cosmo_fxd_field(default=0)
-    w_0: ArrayLike = cosmo_fxd_field(default=-1)
-    w_a: ArrayLike = cosmo_fxd_field(default=0)
-    k_pivot_Mpc: ArrayLike = cosmo_fxd_field(default=0.05)
+    T_cmb: ArrayLike = fxd_field(default=2.7255)  # Fixsen 2009, arXiv:0911.1955
+    Omega_K: ArrayLike = fxd_field(default=0)
+    w_0: ArrayLike = fxd_field(default=-1)
+    w_a: ArrayLike = fxd_field(default=0)
+    k_pivot_Mpc: ArrayLike = fxd_field(default=0.05)
 
     # constants in SI units
-    M_sun_SI: ArrayLike = cosmo_fxd_field(default=1.98847e30)
-    Mpc_SI: ArrayLike = cosmo_fxd_field(default=3.0856775815e22)
-    H_0_SI: ArrayLike = cosmo_fxd_field(default_function=lambda self: 1e5 / self.Mpc_SI)
-    c_SI: ArrayLike = cosmo_fxd_field(default=299792458)
-    G_SI: ArrayLike = cosmo_fxd_field(default=6.67430e-11)
+    M_sun_SI: ArrayLike = fxd_field(default=1.98847e30)
+    Mpc_SI: ArrayLike = fxd_field(default=3.0856775815e22)
+    H_0_SI: ArrayLike = fxd_field(default_function=lambda self: 1e5 / self.Mpc_SI)
+    c_SI: ArrayLike = fxd_field(default=299792458)
+    G_SI: ArrayLike = fxd_field(default=6.67430e-11)
 
     # units in SI units
-    M: ArrayLike = cosmo_fxd_field(default_function=lambda self: 1e10 * self.M_sun_SI)
-    L: ArrayLike = cosmo_fxd_field(default_function=lambda self: self.Mpc_SI)
-    T: ArrayLike = cosmo_fxd_field(default_function=lambda self: 1 / self.H_0_SI)
+    M: ArrayLike = fxd_field(default_function=lambda self: 1e10 * self.M_sun_SI)
+    L: ArrayLike = fxd_field(default_function=lambda self: self.Mpc_SI)
+    T: ArrayLike = fxd_field(default_function=lambda self: 1 / self.H_0_SI)
 
     distance_lga_min: float = aux_field(default=-3)
     distance_lga_max: float = aux_field(default=1)
@@ -264,7 +264,7 @@ class Cosmology(DataTree):
 
     @property
     def distance_a(self):
-        """Distance scale factors."""
+        """Distance scale factors, starting from 0."""
         a = jnp.logspace(self.distance_lga_min, self.distance_lga_max,
                          num=self.distance_a_num - 1, dtype=self.dtype)
         return jnp.concatenate((jnp.array([0]), a))
@@ -283,7 +283,7 @@ class Cosmology(DataTree):
 
     @property
     def transfer_k(self):
-        """Transfer function wavenumbers in :math:`1/L`."""
+        """Transfer function wavenumbers in :math:`1/L`, starting from 0."""
         k = jnp.logspace(self.transfer_lgk_min, self.transfer_lgk_max,
                          num=self.transfer_k_num - 1, dtype=self.dtype)
         return jnp.concatenate((jnp.array([0]), k))

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -6,8 +6,11 @@ from jax.typing import ArrayLike, DTypeLike
 import jax.numpy as jnp
 from mcfit import mcfit, TophatVar
 
-from pmwd import background, perturbation
-from pmwd.tree_util import Tree, TanMixin, pytree_dataclass, dyn_field, fxd_field, aux_field, issubdtype_of, asarray_of
+from pmwd.constants import Constants
+from pmwd.background import distance_cache
+from pmwd.perturbation import transfer_cache, growth_cache, varlin_cache, varlin
+from pmwd.tree_util import (Tree, TanMixin, pytree_dataclass, dyn_field, fxd_field,
+                            aux_field, field, issubdtype_of, asarray_of)
 
 
 cosmo_dyn_field = partial(dyn_field, validate=asarray_of(field='dtype'))
@@ -57,16 +60,8 @@ class Cosmology(TanMixin, Tree):
         Dark energy equation of state linear parameter :math:`w_a`.
     k_pivot_Mpc : float ArrayLike, optional
         Primordial scalar power spectrum pivot scale :math:`k_\mathrm{pivot}` in 1/Mpc.
-    M_sun_SI : float ArrayLike, optional
-        Solar mass :math:`M_\odot` in kg.
-    Mpc_SI : float ArrayLike, optional
-        Mpc in m.
-    H_0_SI : float ArrayLike, optional
-        Hubble constant :math:`H_0` in :math:`h`/s.
-    c_SI : float ArrayLike, optional
-        Speed of light :math:`c` in m/s.
-    G_SI : float ArrayLike, optional
-        Gravitational constant :math:`G` in m:math:`^3`/kg/s:math:`^2`
+    const : Constants, optional
+        Physical constants in SI units.
     M : float ArrayLike, optional
         Mass unit :math:`M` defined in kg/:math:`h`. Default is :math:`10^{10}
         M_\odot/h`.
@@ -133,37 +128,30 @@ class Cosmology(TanMixin, Tree):
     h: ArrayLike = cosmo_dyn_field()
 
     T_cmb: ArrayLike = fxd_field(default=2.7255)  # Fixsen 2009, arXiv:0911.1955
-    Omega_K: ArrayLike = fxd_field(default=0)
-    w_0: ArrayLike = fxd_field(default=-1)
-    w_a: ArrayLike = fxd_field(default=0)
+    Omega_K: ArrayLike = fxd_field(default=0.)
+    w_0: ArrayLike = fxd_field(default=-1.)
+    w_a: ArrayLike = fxd_field(default=0.)
     k_pivot_Mpc: ArrayLike = fxd_field(default=0.05)
 
-    # constants in SI units
-    M_sun_SI: ArrayLike = fxd_field(default=1.98847e30)
-    Mpc_SI: ArrayLike = fxd_field(default=3.0856775815e22)
-    H_0_SI: ArrayLike = fxd_field(depend=lambda self: 1e5 / self.Mpc_SI)
-    c_SI: ArrayLike = fxd_field(default=299792458)
-    G_SI: ArrayLike = fxd_field(default=6.67430e-11)
+    const: Constants = field(depend=lambda self: Constants(), repr=False)
 
     # units in SI units
-    M: ArrayLike = fxd_field(depend=lambda self: 1e10 * self.M_sun_SI)
-    L: ArrayLike = fxd_field(depend=lambda self: self.Mpc_SI)
-    T: ArrayLike = fxd_field(depend=lambda self: 1 / self.H_0_SI)
+    M: ArrayLike = fxd_field(depend=lambda self: 1e10 * self.const.M_sun)
+    L: ArrayLike = fxd_field(depend=lambda self: self.const.Mpc)
+    T: ArrayLike = fxd_field(depend=lambda self: 1 / self.const.H_0)
     A: ArrayLike = fxd_field(default=jnp.pi/(180*3600))
 
     distance_lga_min: float = aux_field(default=-3)
     distance_lga_max: float = aux_field(default=1)
     distance_lga_maxstep: float = aux_field(default=1/128)
-    distance: Array | None = cosmo_dyn_field(cache=background.distance_cache,
-                                             compare=False)
+    distance: Array | None = cosmo_dyn_field(cache=distance_cache, compare=False)
 
     transfer_fit: bool = aux_field(default=True)
     transfer_fit_nowiggle: bool = aux_field(default=False)
     transfer_lgk_min: float = aux_field(default=-4)
     transfer_lgk_max: float = aux_field(default=3)
     transfer_lgk_maxstep: float = aux_field(default=1/128)
-    transfer: Array | None = cosmo_dyn_field(cache=perturbation.transfer_cache,
-                                             compare=False)
+    transfer: Array | None = cosmo_dyn_field(cache=transfer_cache, compare=False)
 
     growth_rtol: float = aux_field(depend=lambda self: _eps2tol(self.dtype))
     growth_atol: float = aux_field(depend=lambda self: _eps2tol(self.dtype))
@@ -172,11 +160,9 @@ class Cosmology(TanMixin, Tree):
     growth_lga_min: float = aux_field(default=-3)
     growth_lga_max: float = aux_field(default=1)
     growth_lga_maxstep: float = aux_field(default=1/128)
-    growth: Array | None = cosmo_dyn_field(cache=perturbation.growth_cache,
-                                           compare=False)
+    growth: Array | None = cosmo_dyn_field(cache=growth_cache, compare=False)
 
-    varlin: Array | None = cosmo_dyn_field(cache=perturbation.varlin_cache,
-                                           compare=False)
+    varlin: Array | None = cosmo_dyn_field(cache=varlin_cache, compare=False)
 
     #FIXME although mcfit.mcfit is hashable but maybe this can be more functional
     _var_tophat: mcfit = aux_field(depend=_init_var_tophat)
@@ -198,17 +184,17 @@ class Cosmology(TanMixin, Tree):
     @property
     def H_0(self):
         """Hubble constant :math:`H_0` in :math:`1/T`."""
-        return self.H_0_SI * self.T
+        return self.const.H_0 * self.T
 
     @property
     def c(self):
         """Speed of light :math:`c` in :math:`L/T`."""
-        return self.c_SI * self.T / self.L
+        return self.const.c * self.T / self.L
 
     @property
     def G(self):
         """Gravitational constant :math:`G` in :math:`L^3 / M / T^2`."""
-        return self.G_SI * self.M * self.T**2 / self.L**3
+        return self.const.G * self.M * self.T**2 / self.L**3
 
     @property
     def d_H(self):
@@ -223,7 +209,7 @@ class Cosmology(TanMixin, Tree):
     @property
     def k_pivot(self):
         r"""Primordial scalar power spectrum pivot scale :math:`k_\mathrm{pivot}` in :math:`1/L`."""
-        return self.k_pivot_Mpc / (self.h * self.Mpc_SI) * self.L
+        return self.k_pivot_Mpc / (self.h * self.const.Mpc) * self.L
 
     @property
     def A_s(self):
@@ -247,9 +233,10 @@ class Cosmology(TanMixin, Tree):
 
     @property
     def sigma_8(self):
-        r"""Linear matter rms overdensity within a tophat sphere of 8 Mpc/:math:`h` radius today :math:`\sigma_8`."""
-        R = 8 * self.Mpc_SI / self.L
-        return jnp.sqrt(perturbation.varlin(R, 1, self))
+        r"""Linear matter rms overdensity within a tophat sphere of 8 Mpc/:math:`h`
+        radius today :math:`\sigma_8`."""
+        R = 8 * self.const.Mpc / self.L
+        return jnp.sqrt(varlin(R, 1, self))
 
     @property
     def distance_a_num(self):

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -1,5 +1,6 @@
 from functools import partial
 import math
+from types import MappingProxyType
 
 from jax import Array, ensure_compile_time_eval
 from jax.typing import ArrayLike, DTypeLike
@@ -302,22 +303,20 @@ class Cosmology(TanMixin, Tree):
         return self._var_tophat.y
 
 
-SimpleLCDM = partial(
-    Cosmology,
+# Simple ΛCDM cosmology, for convenience and subject to change
+simple_LCDM = MappingProxyType(dict(
     A_s_1e9=2.0,
     n_s=0.96,
     Omega_m=0.3,
     Omega_b=0.05,
     h=0.7,
-)
-SimpleLCDM.__doc__ = 'Simple ΛCDM cosmology, for convenience and subject to change.'
+))
 
-Planck18 = partial(
-    Cosmology,
+# Planck 2018 cosmology, arXiv:1807.06209 Table 2 last column
+Planck_18 = MappingProxyType(dict(
     A_s_1e9=2.105,
     n_s=0.9665,
     Omega_m=0.3111,
     Omega_b=0.04897,
     h=0.6766,
-)
-Planck18.__doc__ = 'Planck 2018 cosmology, arXiv:1807.06209 Table 2 last column.'
+))

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -11,7 +11,7 @@ from pmwd.constants import Constants
 from pmwd.background import distance_cache
 from pmwd.perturbation import transfer_cache, growth_cache, varlin_cache, varlin
 from pmwd.tree_util import (Tree, TanMixin, pytree_dataclass, dyn_field, fxd_field,
-                            aux_field, field, issubdtype_of, asarray_of)
+                            aux_field, issubdtype_of, asarray_of)
 
 
 cosmo_dyn_field = partial(dyn_field, validate=asarray_of(field='dtype'))
@@ -64,16 +64,15 @@ class Cosmology(TanMixin, Tree):
     const : Constants, optional
         Physical constants in SI units.
     M : float ArrayLike, optional
-        Mass unit :math:`M` defined in kg/:math:`h`. Default is :math:`10^{10}
-        M_\odot/h`.
+        Mass unit :math:`M` in kg/:math:`h`. Default is :math:`10^{10} M_\odot/h`.
     L : float ArrayLike, optional
-        Length unit :math:`L` defined in m/:math:`h`. Default is Mpc/:math:`h`.
+        Length unit :math:`L` in m/:math:`h`. Default is Mpc/:math:`h`.
     T : float ArrayLike, optional
-        Time unit :math:`T` defined in s/:math:`h`. Default is Hubble time :math:`1/H_0
-        \sim 10^{10}` years/:math:`h \sim` age of the Universe. So the default velocity
-        unit is :math:`L/T =` 100 km/s.
+        Time unit :math:`T` in s/:math:`h`. Default is Hubble time :math:`1/H_0 \sim
+        10^{10}` years/:math:`h \sim` age of the Universe. So the default velocity unit
+        is :math:`L/T =` 100 km/s.
     A : float ArrayLike, optional
-        Angular unit defined in radians. Default is arcsec.
+        Angular unit in radians. Default is arcsec.
     distance_lga_min : float, optional
         Minimum distance scale factor in log10.
     distance_lga_max : float, optional
@@ -134,9 +133,8 @@ class Cosmology(TanMixin, Tree):
     w_a: ArrayLike = fxd_field(default=0.)
     k_pivot_Mpc: ArrayLike = fxd_field(default=0.05)
 
-    const: Constants = field(depend=lambda self: Constants(), repr=False)
+    const: Constants = dyn_field(depend=lambda self: Constants(), repr=False)
 
-    # units in SI units
     M: ArrayLike = fxd_field(depend=lambda self: 1e10 * self.const.M_sun)
     L: ArrayLike = fxd_field(depend=lambda self: self.const.Mpc)
     T: ArrayLike = fxd_field(depend=lambda self: 1 / self.const.H_0)

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -141,14 +141,14 @@ class Cosmology(TanMixin, Tree):
     # constants in SI units
     M_sun_SI: ArrayLike = fxd_field(default=1.98847e30)
     Mpc_SI: ArrayLike = fxd_field(default=3.0856775815e22)
-    H_0_SI: ArrayLike = fxd_field(default_function=lambda self: 1e5 / self.Mpc_SI)
+    H_0_SI: ArrayLike = fxd_field(depend=lambda self: 1e5 / self.Mpc_SI)
     c_SI: ArrayLike = fxd_field(default=299792458)
     G_SI: ArrayLike = fxd_field(default=6.67430e-11)
 
     # units in SI units
-    M: ArrayLike = fxd_field(default_function=lambda self: 1e10 * self.M_sun_SI)
-    L: ArrayLike = fxd_field(default_function=lambda self: self.Mpc_SI)
-    T: ArrayLike = fxd_field(default_function=lambda self: 1 / self.H_0_SI)
+    M: ArrayLike = fxd_field(depend=lambda self: 1e10 * self.M_sun_SI)
+    L: ArrayLike = fxd_field(depend=lambda self: self.Mpc_SI)
+    T: ArrayLike = fxd_field(depend=lambda self: 1 / self.H_0_SI)
     A: ArrayLike = fxd_field(default=jnp.pi/(180*3600))
 
     distance_lga_min: float = aux_field(default=-3)
@@ -165,8 +165,8 @@ class Cosmology(TanMixin, Tree):
     transfer: Array | None = cosmo_dyn_field(cache=perturbation.transfer_cache,
                                              compare=False)
 
-    growth_rtol: float = aux_field(default_function=lambda self: _eps2tol(self.dtype))
-    growth_atol: float = aux_field(default_function=lambda self: _eps2tol(self.dtype))
+    growth_rtol: float = aux_field(depend=lambda self: _eps2tol(self.dtype))
+    growth_atol: float = aux_field(depend=lambda self: _eps2tol(self.dtype))
     growth_inistep: (float | None
                      | tuple[float|None, float|None]) = aux_field(default=(1, 1))  # FIXME (1, None) used to work? but now also causes nan in sigma_8 gradients
     growth_lga_min: float = aux_field(default=-3)
@@ -179,7 +179,7 @@ class Cosmology(TanMixin, Tree):
                                            compare=False)
 
     #FIXME although mcfit.mcfit is hashable but maybe this can be more functional
-    _var_tophat: mcfit = aux_field(default_function=_init_var_tophat)
+    _var_tophat: mcfit = aux_field(depend=_init_var_tophat)
 
     @classmethod
     def from_sigma_8(cls, sigma_8, *args, **kwargs):

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -76,6 +76,8 @@ class Cosmology(TanMixin, Tree):
         Time unit :math:`T` defined in s/:math:`h`. Default is Hubble time :math:`1/H_0
         \sim 10^{10}` years/:math:`h \sim` age of the Universe. So the default velocity
         unit is :math:`L/T =` 100 km/s.
+    A : float ArrayLike, optional
+        Angular unit defined in radians. Default is arcsec.
     distance_lga_min : float, optional
         Minimum distance scale factor in log10.
     distance_lga_max : float, optional
@@ -121,8 +123,6 @@ class Cosmology(TanMixin, Tree):
 
     """
 
-    # TODO keyword-only for python>=3.10
-
     dtype: DTypeLike = aux_field(default=float,
                                  validate=(jnp.dtype, issubdtype_of(jnp.floating)))
 
@@ -149,6 +149,7 @@ class Cosmology(TanMixin, Tree):
     M: ArrayLike = fxd_field(default_function=lambda self: 1e10 * self.M_sun_SI)
     L: ArrayLike = fxd_field(default_function=lambda self: self.Mpc_SI)
     T: ArrayLike = fxd_field(default_function=lambda self: 1 / self.H_0_SI)
+    A: ArrayLike = fxd_field(default=jnp.pi/(180*3600))
 
     distance_lga_min: float = aux_field(default=-3)
     distance_lga_max: float = aux_field(default=1)

--- a/pmwd/perturbation.py
+++ b/pmwd/perturbation.py
@@ -16,7 +16,7 @@ def transfer_cache(cosmo):
     Returns
     -------
     cosmo : Cosmology
-        A new instance containing a transfer table, in shape ``(cosmo.transfer_k_num,)``
+        A new object containing a transfer table, in shape ``(cosmo.transfer_k_num,)``
         and precision ``cosmo.dtype``.
 
     """
@@ -166,7 +166,7 @@ def growth_cache(cosmo):
     Returns
     -------
     cosmo : Cosmology
-        A new instance containing a growth table, in shape ``(num_lpt_order,
+        A new object containing a growth table, in shape ``(num_lpt_order,
         num_derivatives, len(cosmo.growth_a))`` and precision ``cosmo.dtype``.
 
     Notes
@@ -175,7 +175,7 @@ def growth_cache(cosmo):
 
     """
     with ensure_compile_time_eval():  # FIXME math.cbrt for python >= 3.11
-        eps = jnp.finfo(cosmo.Omega_m.dtype).eps
+        eps = jnp.finfo(cosmo.dtype).eps
         a_ic = 0.5 * jnp.cbrt(eps).item()  # ~ 3e-6 for float64, 2e-3 for float32
         a_ic = min(a_ic, 0.5 * 10**cosmo.growth_lga_min)
 
@@ -195,7 +195,7 @@ def growth_cache(cosmo):
         G2pp = Omega_fac * G1**2 - (8 + 2*dlnH_dlna - Omega_fac) * G2 - (6 + dlnH_dlna) * G2p
         return jnp.concatenate((G1p, G1pp, G2p, G2pp), axis=-1)
 
-    G_ic = jnp.array((1, 0, 3/7, 0), dtype=cosmo.Omega_m.dtype)
+    G_ic = jnp.array((1, 0, 3/7, 0), dtype=cosmo.dtype)
 
     G = odeint(ode, G_ic, lna, cosmo,
                rtol=cosmo.growth_rtol, atol=cosmo.growth_atol, dt0=cosmo.growth_inistep)
@@ -269,7 +269,7 @@ def varlin_cache(cosmo):
     Returns
     -------
     cosmo : Cosmology
-        A new instance containing a linear variance table, in shape
+        A new object containing a linear variance table, in shape
         ``(len(cosmo.varlin_R),)`` and precision ``cosmo.dtype``.
 
     """

--- a/pmwd/perturbation.py
+++ b/pmwd/perturbation.py
@@ -1,3 +1,5 @@
+import math
+
 from jax import jit, custom_vjp, ensure_compile_time_eval
 import jax.numpy as jnp
 
@@ -171,10 +173,9 @@ def growth_cache(cosmo):
     TODO: ODE math
 
     """
-    with ensure_compile_time_eval():  # FIXME math.cbrt for python >= 3.11
-        eps = jnp.finfo(cosmo.dtype).eps
-        a_ic = 0.5 * jnp.cbrt(eps).item()  # ~ 3e-6 for float64, 2e-3 for float32
-        a_ic = min(a_ic, 0.5 * 10**cosmo.growth_lga_min)
+    eps = jnp.finfo(cosmo.dtype).eps
+    a_ic = 0.5 * math.cbrt(eps)  # ~ 3e-6 for float64, 2e-3 for float32
+    a_ic = min(a_ic, 0.5 * 10**cosmo.growth_lga_min)
 
     a = cosmo.growth_a
     lna = jnp.log(a.at[0].set(a_ic))

--- a/pmwd/perturbation.py
+++ b/pmwd/perturbation.py
@@ -53,7 +53,7 @@ def transfer_fit(k, cosmo):
     """
     k = jnp.asarray(k)
 
-    k = k * cosmo.h / cosmo.L * cosmo.Mpc_SI  # unit conversion to 1/Mpc
+    k = k * cosmo.h / cosmo.L * cosmo.const.Mpc  # unit conversion to 1/Mpc
 
     T2_cmb_norm = (cosmo.T_cmb / 2.7)**2
     h2 = cosmo.h**2

--- a/pmwd/perturbation.py
+++ b/pmwd/perturbation.py
@@ -7,7 +7,7 @@ from pmwd.ode_util import odeint
 
 @jit
 def transfer_cache(cosmo):
-    """Cache the matter transfer function table at ``cosmo.transfer_k``.
+    """Matter transfer function table at ``cosmo.transfer_k``.
 
     Parameters
     ----------
@@ -15,9 +15,8 @@ def transfer_cache(cosmo):
 
     Returns
     -------
-    cosmo : Cosmology
-        A new object containing a transfer table, in shape ``(cosmo.transfer_k_num,)``
-        and precision ``cosmo.dtype``.
+    transfer : jax.Array of cosmo.dtype and shape (cosmo.transfer_k_num,)
+        Transfer table.
 
     """
     if cosmo.transfer_fit:
@@ -30,7 +29,6 @@ def transfer_cache(cosmo):
 
 # TODO Wayne's website: neutrino no wiggle case
 # TODO test on n-dim k to compare with fixed values
-# TODO add Bartlett et al.
 def transfer_fit(k, cosmo):
     """Eisenstein & Hu fit of matter transfer function.
 
@@ -146,7 +144,7 @@ def transfer(k, cosmo):
 
     """
     if cosmo.transfer is None:
-        raise ValueError('transfer table is empty: run Cosmology.cache or transfer_cache first')
+        raise ValueError('transfer table is empty: run Cosmology.cache first')
 
     k = jnp.asarray(k)
 
@@ -157,7 +155,7 @@ def transfer(k, cosmo):
 
 @jit
 def growth_cache(cosmo):
-    r"""Cache the (LPT) growth function and derivative tables at ``cosmo.growth_a``.
+    r"""LPT growth function and derivative tables at ``cosmo.growth_a``.
 
     Parameters
     ----------
@@ -165,9 +163,8 @@ def growth_cache(cosmo):
 
     Returns
     -------
-    cosmo : Cosmology
-        A new object containing a growth table, in shape ``(num_lpt_order,
-        num_derivatives, len(cosmo.growth_a))`` and precision ``cosmo.dtype``.
+    growth : jax.Array of cosmo.dtype and shape (num_lpt_order, num_derivatives, len(cosmo.growth_a))
+        Growth table.
 
     Notes
     -----
@@ -249,7 +246,7 @@ def growth(a, cosmo, order=1, deriv=0):
 
     """
     if cosmo.growth is None:
-        raise ValueError('growth table is empty: run Cosmology.cache or growth_cache first')
+        raise ValueError('growth table is empty: run Cosmology.cache first')
 
     a = jnp.asarray(a)
 
@@ -259,7 +256,7 @@ def growth(a, cosmo, order=1, deriv=0):
 
 
 def varlin_cache(cosmo):
-    """Cache the linear matter overdensity variance table within tophat spheres of
+    """Linear matter overdensity variance table within tophat spheres of
     ``cosmo.varlin_R`` radii.
 
     Parameters
@@ -268,9 +265,8 @@ def varlin_cache(cosmo):
 
     Returns
     -------
-    cosmo : Cosmology
-        A new object containing a linear variance table, in shape
-        ``(len(cosmo.varlin_R),)`` and precision ``cosmo.dtype``.
+    varlin : jax.Array of cosmo.dtype and shape (len(cosmo.varlin_R),)
+        Linear variance table.
 
     """
     Plin = linear_power(cosmo._var_tophat.x, None, cosmo)
@@ -304,7 +300,7 @@ def varlin(R, a, cosmo):
 
     """
     if cosmo.varlin is None:
-        raise ValueError('varlin table is empty: run Cosmology.cache or varlin_cache first')
+        raise ValueError('varlin table is empty: run Cosmology.cache first')
 
     R = jnp.asarray(R)
 

--- a/pmwd/pm_util.py
+++ b/pmwd/pm_util.py
@@ -1,3 +1,8 @@
+from functools import reduce
+import math
+
+import jax
+import jax.extend
 import jax.numpy as jnp
 
 
@@ -342,3 +347,55 @@ def fftinv(f, shape=None, axes=None, norm=None):
         d = len(axes)
 
     return norm**-d * jnp.fft.irfftn(f, s=shape, axes=axes, norm='backward')
+
+
+def fftlen(n, platform=None):
+    """Find the next fast length for FFT on the platform.
+
+    Parameters
+    ----------
+    n : float
+        FFT length to start searching from.
+    platform : str or xla_client.Client, optional
+        Platform supported by XLA. Default is the platform of the default backend.
+
+    .. _ducc0/fft good_size_real:
+        https://gitlab.mpcdf.mpg.de/mtr/ducc/-/blob/ducc0/src/ducc0/fft/fft.h
+    .. _rocFFT:
+        https://rocm.docs.amd.com/projects/rocFFT
+    .. _cuFFT:
+        https://docs.nvidia.com/cuda/cufft/index.html#accuracy-and-performance
+
+    """
+    platform = jax.extend.backend.get_backend(platform=platform).platform
+
+    if platform == 'cpu':
+        radices = [2, 3, 5]
+    elif platform == 'rocm':
+        radices = [2, 3, 5, 7, 11, 13, 17]
+    elif platform in ['cuda', 'gpu']:
+        radices = [2, 3, 5, 7]
+    else:
+        raise NotImprementedError
+
+    return fftlen_(n, radices)
+
+
+def fftlen_(n, radices):
+    """Find the next fast length for FFT given radices.
+
+    Parameters
+    ----------
+    n : float
+        FFT length to start searching from.
+    radices : sequence of (prime) int
+        FFT radices.
+
+    """
+    if n <= max(radices):
+        return n
+
+    with jax.ensure_compile_time_eval():
+        powers = [r ** (jnp.arange(1 + math.floor(math.log(2*n, r)))) for r in radices]
+        products = reduce(jnp.kron, powers)
+        return products[products >= n].min().item()

--- a/pmwd/spec_util.py
+++ b/pmwd/spec_util.py
@@ -47,7 +47,7 @@ def _getbins(grid_shape, bins, cut_nyq):
     return bnum, bcut, bins, right
 
 
-@partial(jit, static_argnames=('bins', 'cut_zero', 'cut_nyq', 'dtype', 'int_dtype'))
+@partial(jit, static_argnums=(2, 4, 5, 6, 7, 8))
 def powspec(f, spacing, bins=1j/3, g=None, deconv=None, cut_zero=True, cut_nyq=True,
             dtype=jnp.float64, int_dtype=jnp.uint32):
     """Compute auto or cross power spectrum in 3D averaged in spherical bins.

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -181,17 +181,18 @@ def pytree_dataclass(cls, aux_fields=None, **kwargs):
     cls.aux_data_with_names = aux_data_with_names
     cls.aux_data = aux_data
 
-    def flatten_with_keys(obj):
-        return tuple(obj.children_with_keys()), tuple(obj.aux_data())
+    def tree_flatten_with_keys(obj):
+        return list(obj.children_with_keys()), list(obj.aux_data())
 
-    def flatten(obj):
-        return tuple(obj.children()), tuple(obj.aux_data())
+    def tree_flatten(obj):
+        return list(obj.children()), list(obj.aux_data())
 
-    def unflatten(aux_data, children):
+    def tree_unflatten(aux_data, children):
         return cls(**dict(zip(children_names, children)),
                    **dict(zip(aux_data_names, aux_data)))
 
-    register_pytree_with_keys(cls, flatten_with_keys, unflatten, flatten_func=flatten)
+    register_pytree_with_keys(cls, tree_flatten_with_keys, tree_unflatten,
+                              flatten_func=tree_flatten)
 
     def _is_transforming(self):
         """Whether dataclass fields are pytrees initialized by JAX transformations.

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -7,16 +7,16 @@ from jax.tree_util import register_pytree_node, tree_leaves
 def pytree_dataclass(cls, aux_fields=None, aux_invert=False, **kwargs):
     """Register python dataclasses as custom pytree nodes.
 
-    Also added are methods that return children and aux_data iterators, and pretty
-    string representation, and a method that replace fields with changes.
+    Also added are methods that return children and aux_data iterators, pretty string
+    representation, and a method that replace fields with changes.
 
     Parameters
     ----------
     cls : type
         Class to be registered, not a python dataclass yet.
-    aux_fields : str, sequence of str, or Ellipsis, optional
-        Pytree aux_data fields. Default is none; unrecognized ones are ignored;
-        ``Ellipsis`` uses all.
+    aux_fields : str, iterable of str, or Ellipsis, optional
+        Pytree aux_data fields, or child (leaf) fields if ``aux_invert``. Default is
+        none; unrecognized ones are ignored; ``Ellipsis`` uses all.
     aux_invert : bool, optional
         Whether to invert ``aux_fields`` selections, convenient when most but not all
         fields are aux_data.

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -1,16 +1,478 @@
+from abc import ABC, abstractmethod
+from collections.abc import Callable
 import dataclasses
+from enum import Flag, auto
+from functools import partial
 from pprint import pformat
 
-from jax.tree_util import GetAttrKey, register_pytree_with_keys, tree_leaves
+import jax.numpy as jnp
+from jax.tree_util import GetAttrKey, register_pytree_with_keys, tree_leaves, tree_map
 from jax.lax import stop_gradient
 
+from pmwd.util import add, sub, neg, scalar_mul, scalar_div
 
-def pytree_dataclass(cls, aux_fields=None, **kwargs):
+
+class FType(Flag):
+    """Pytree dataclass field types."""
+    DYNAMIC = auto()
+    FIXED = auto()
+    AUXILIARY = auto()
+    CHILD = DYNAMIC | FIXED
+FType.DYNAMIC.__doc__ = 'Dynamic pytree children with gradients.'
+FType.FIXED.__doc__ = 'Fixed pytree children without gradients.'
+FType.CHILD.__doc__ = 'Pytree children, dynamic or fixed.'
+FType.AUXILIARY.__doc__ = 'Auxiliary data stored in pytree treedef.'
+
+
+# FIXME passing tuple (jnp.dtype, issubdtype_of(jnp.floating)) for dtype validation
+def issubdtype_of(dtype):
+    def fun(test_dtype):
+        if not jnp.issubdtype(test_dtype, dtype):
+            raise ValueError(f'{test_dtype!r} must be sub-dtype of {dtype!r}')
+        return test_dtype
+    return fun
+
+
+def asarray_of(dtype=None):
+    def fun(value):
+        return tree_map(partial(jnp.asarray, dtype=dtype), value)
+    return fun
+
+
+def _astuple_of_callables(fun):
+    if fun is None:
+        fun = ()
+    elif isinstance(fun, Callable):
+        fun = (fun,)
+    else:
+        fun = tuple(fun)
+    return fun
+
+
+def _is_jax_placeholder(obj):
+    """Whether an object is a placeholder traced by JAX transformations.
+
+    .. _Pytrees — JAX documentation:
+        https://jax.readthedocs.io/en/latest/pytrees.html#custom-pytrees-and-initialization
+
+    .. _JAX Issue #10238:
+        https://github.com/google/jax/issues/10238
+
+    """
+    return type(obj) is object
+
+
+# FIXME maybe not useful anymore
+#def _is_transforming(self):
+#    """Whether fields are placeholders traced by JAX transformations.
+#
+#    .. _Pytrees — JAX documentation:
+#        https://jax.readthedocs.io/en/latest/pytrees.html#custom-pytrees-and-initialization
+#
+#    .. _JAX Issue #10238:
+#        https://github.com/google/jax/issues/10238
+#
+#    """
+#    def leaves_all(is_placeholder, tree):
+#        # similar to tree_all(tree_map(is_placeholder, tree))
+#        return all(is_placeholder(x) for x in tree_leaves(tree))
+#
+#    # unnecessary to test for None's since they are empty pytree nodes
+#    return tree_leaves(self) and leaves_all(_is_jax_placeholder, self)
+
+
+class DataDescriptor:
+    """Descriptor to specify computation rules of described data.
+
+    Parameters
+    ----------
+    mandatory : bool, optional
+        Whether the value must be initialized to something other than ``None``, if none
+        of ``default``, ``default_function``, or ``cache`` is specified.
+    default : pytree, optional
+        Default value.
+    default_function : callable or None, optional
+        Default function to compute the value, if not already initialized to anything
+        else but ``None``, from the instance of the owner class, ``value =
+        default_function(obj)``, runned by e.g. ``DataTree.__post_init__``.
+    cache : callable or None, optional
+        Caching function to compute the value from the instance of the owner class,
+        ``value = cache(obj)``, runned by e.g. ``DataTree.cache``.
+    validate : callable, sequence of callable, or None, optional
+        Validator functions before setting the value, ``value = validate(value)``. If a
+        sequence, apply each in turn. Skipped if ``value is None``, or if ``type(value)
+        is object`` to avoid validating JAX placeholders.
+    transform : callable, sequence of callable, or None, optional
+        Transformer functions after getting the value, ``value = transform(value)``. If
+        a sequence, apply each in turn. Skipped if ``value is None``, or if
+        ``type(value) is object`` to avoid transforming JAX placeholders. Useful with
+        `lax.stop_gradient`.
+
+    Methods?
+    -------
+    FIXME
+
+    Raises
+    ------
+    ValueError
+        If more than one is specified among ``default``, ``default_function``, and
+        ``cache``, or if mandatory data is missing when none of the three is specified.
+    TypeError
+        If trying to set or delete descriptor attributes.
+
+    .. _Python Descriptor HowTo Guide:
+        https://docs.python.org/3/howto/descriptor.html
+
+    .. _Python Data Model - Implementing Descriptors:
+        https://docs.python.org/3/reference/datamodel.html#implementing-descriptors
+
+    .. _Python Data Model - Invoking Descriptors:
+        https://docs.python.org/3/reference/datamodel.html#invoking-descriptors
+
+    .. _Python Data Classes:
+        https://docs.python.org/3/library/dataclasses.html#descriptor-typed-fields
+
+    .. _Combining a descriptor class with dataclass and field:
+        https://stackoverflow.com/questions/67612451/combining-a-descriptor-class-with-dataclass-and-field
+
+    .. _Google etils dataclass field descriptor:
+        https://github.com/google/etils/blob/main/etils/edc/field_utils.py
+
+    .. _FIXME Dataclass descriptor behavior inconsistent:
+        https://github.com/python/cpython/issues/102646
+
+    """
+
+    __slots__ = (
+        'mandatory',
+        'default',
+        'default_function',
+        'cache',
+        'validate',
+        'transform',
+        '_name',
+    )
+
+    def __init__(self, mandatory=True, default=None, default_function=None, cache=None,
+                 validate=None, transform=None):
+        if sum(x is not None for x in (default, default_function, cache)) > 1:
+            raise ValueError(f'{default=}, {default_function=}, and {cache=} are '
+                             'mutually exclusive')
+
+        validate = _astuple_of_callables(validate)
+        transform = _astuple_of_callables(transform)
+
+        object.__setattr__(self, 'mandatory', mandatory)
+        object.__setattr__(self, 'default', default)
+        object.__setattr__(self, 'default_function', default_function)
+        object.__setattr__(self, 'cache', cache)
+        object.__setattr__(self, 'validate', validate)
+        object.__setattr__(self, 'transform', transform)
+
+    def __repr__(self):
+        return (
+            f'{__class__.__name__}('
+            f'mandatory={self.mandatory}, '
+            f'default={self.default!r}, '
+            f'default_function={self.default_function!r}, '
+            f'cache={self.cache!r}, '
+            f'validate={self.validate!r}, '
+            f'transform={self.transform!r})'
+        )
+
+    def __setattr__(self, name, value):
+        raise TypeError(f'{self.__class__} is read-only')
+
+    def __delattr__(self, name):
+        raise TypeError(f'{self.__class__} is read-only')
+
+    def __set_name__(self, objtype, name):
+        object.__setattr__(self, '_name', '_' + name)
+
+    def __get__(self, obj, objtype=None):
+        #print(f'__get__: {type(obj)=!r}, {obj=!r}', flush=True)
+        #print(f'__get__: {type(objtype)=!r}, {objtype=!r}', flush=True)
+        if obj is None:  # name: type = descr
+            #print(f'__get__: obj is None, {objtype=!r}', flush=True)
+            return self.default
+        value = getattr(obj, self._name)
+        return self.run_transform(value)
+
+    def __set__(self, obj, value):
+        #try:
+        #    print(f'__set__: {type(obj)=!r}, {obj=!r}', flush=True)
+        #except AttributeError:
+        #    print(f'__set__: {type(obj)=!r}, CANNOT print(obj)', flush=True)
+        #print(f'__set__: {type(value)=!r}, {value=!r}', flush=True)
+        if value is self:  # name: type = field(default=descr, ...)
+            #print(f'__set__: {value=!r} is self', flush=True)
+            value = self.default
+        value = self.run_validate(value)
+        object.__setattr__(obj, self._name, value)
+
+    def raise_missing(self, obj):
+        if self.mandatory and all(x is None for x in (
+                self.default, self.default_function, self.cache, self.__get__(obj))):
+            raise ValueError('mandatory data missing')
+
+    def run_default_function(self, obj):
+        if self.default_function is None or self.__get__(obj) is not None:
+            return obj
+        value = self.default_function(obj)
+        return value
+
+    def run_cache(self, obj):
+        if self.cache is None:
+            return obj
+        value = self.cache(obj)
+        return value
+
+    def run_validate(self, value):
+        if value is None or _is_jax_placeholder(value):
+            return value
+        for validate in self.validate:
+            value = validate(value)
+        return value
+
+    def run_transform(self, value):
+        if value is None or _is_jax_placeholder(value):
+            return value
+        for transform in self.transform:
+            value = transform(value)
+        return value
+
+
+def _forbid_default_factory(kwargs):
+    if 'default_factory' in kwargs:
+        raise ValueError('default_factory not supported')
+
+
+def _update_metadata(kwargs, ftype):
+    metadata = kwargs.pop('metadata', {})
+    metadata = {} if metadata is None else dict(metadata)
+    metadata['ftype'] = ftype
+    kwargs['metadata'] = metadata
+    return kwargs
+
+
+def dyn_field(*, mandatory=True, default=None, default_function=None, cache=None,
+              validate=None, transform=None, **kwargs):
+    """Descriptor dataclass field for dynamic pytree children.
+
+    ``metadata`` is updated with ``ftype``. ``default_factory`` is not supported. See
+    ``DataDescriptor`` and ``dataclasses.field``.
+
+    Raises
+    ------
+    ValueError
+        If ``default_factory`` is specified.
+
+    """
+    _forbid_default_factory(kwargs)
+    kwargs = _update_metadata(kwargs, FType.DYNAMIC)
+    return dataclasses.field(
+        default=DataDescriptor(mandatory, default, default_function, cache,
+                               validate, transform),
+        **kwargs,
+    )
+
+
+def fxd_field(*, mandatory=True, default=None, default_function=None, cache=None,
+              validate=None, transform=None, repr=False, **kwargs):
+    """Descriptor dataclass field for fixed pytree children.
+
+    ``lax.stop_gradient`` is appended to ``transform`` if not already in it.
+    ``metadata`` is updated with ``ftype``. ``default_factory`` is not supported.
+    ``repr`` is supppressed by default. See ``DataDescriptor`` and
+    ``dataclasses.field``.
+
+    Raises
+    ------
+    ValueError
+        If ``default_factory`` is specified.
+
+    """
+    _forbid_default_factory(kwargs)
+    kwargs = _update_metadata(kwargs, FType.FIXED)
+    transform = _astuple_of_callables(transform)
+    if stop_gradient not in transform:
+        transform += (stop_gradient,)
+    return dataclasses.field(
+        default=DataDescriptor(mandatory, default, default_function, cache,
+                               validate, transform),
+        repr=repr, **kwargs,
+    )
+
+
+def aux_field(*, mandatory=True, default=None, default_function=None, cache=None,
+              validate=None, transform=None, repr=False, **kwargs):
+    """Descriptor dataclass field for auxiliary data.
+
+    ``metadata`` is updated with ``ftype``. ``default_factory`` is not supported.
+    ``repr`` is supppressed by default. See ``DataDescriptor`` and
+    ``dataclasses.field``.
+
+    Raises
+    ------
+    ValueError
+        If ``default_factory`` is specified.
+
+    """
+    _forbid_default_factory(kwargs)
+    kwargs = _update_metadata(kwargs, FType.AUXILIARY)
+    return dataclasses.field(
+        default=DataDescriptor(mandatory, default, default_function, cache,
+                               validate, transform),
+        repr=repr, **kwargs,
+    )
+
+
+class DataTree(ABC):
+    """Base class for combining pytree and dataclass.
+
+    Linear operators (addition, subtraction, and scalar multiplication) are defined for
+    tangent and cotangent vector spaces.
+
+    FIXME add idiom to pytree_dataclass below
+
+    """
+
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    def __add__(self, other):
+        return tree_map(add, self, other)
+
+    def __sub__(self, other):
+        return tree_map(sub, self, other)
+
+    def __neg__(self):
+        return tree_map(neg, self)
+
+    def __mul__(self, scalar):
+        return tree_map(partial(scalar_mul, scalar), self)
+
+    def __rmul__(self, scalar):
+        return self.__mul__(scalar)
+
+    def __truediv__(self, scalar):
+        return tree_map(partial(scalar_div, scalar), self)
+
+    def __str__(self):
+        """Pretty string representation for python >= 3.10."""
+        return pformat(self)
+
+    def __post_init__(self):
+        for name in self.iter_fields(name=True):
+            descr = vars(self.__class__).get(name, None)
+            if isinstance(descr, DataDescriptor):
+                descr.raise_missing(self)
+                value = descr.run_default_function(self)
+                if value is not self:
+                    descr.__set__(self, value)
+
+    def replace(self, **changes):
+        """Create a new object of the same type, replacing fields with changes.
+
+        See ``dataclasses.replace``.
+
+        """
+        return dataclasses.replace(self, **changes)
+
+    def cache(self):
+        """Cache all fields in the order of ``dataclasses.fields``.
+
+        Returns
+        -------
+        instance : DataTree
+            A new instance with all fields cached.
+
+        """
+        obj = self
+        for name in self.iter_fields(name=True):
+            descr = vars(self.__class__).get(name, None)
+            if isinstance(descr, DataDescriptor):
+                value = descr.run_cache(obj)
+                if value is not obj:
+                    obj = obj.replace(**{name: value})
+        return obj
+
+    def purge(self):
+        """Purge all caches.
+
+        Returns
+        -------
+        instance : DataTree
+            A new instance with all cached fields set to ``None``.
+
+        """
+        obj = self
+        for name in self.iter_fields(name=True):
+            descr = vars(self.__class__).get(name, None)
+            if isinstance(descr, DataDescriptor) and descr.cache is not None:
+                obj = obj.replace(**{name: None})
+        return obj
+
+    # FIXME no need to leave things as is now, so this API may not be the best
+    def cache_purge(self, **kwargs):
+        """Cache and/or purge specified fields in the order of ``kwargs``.
+
+        Parameters
+        ----------
+        kwargs
+            Whether to cache a field, leave it as is (default), or set it to ``None``,
+            by passing ``name=True``, ``False``, or ``None``, respectively.
+
+        Returns
+        -------
+        instance : DataTree
+            A new instance containing changed field values.
+
+        Raises
+        ------
+        ValueError
+            If ``kwargs`` has any unrecognized field name or flag value.
+
+        """
+        field_names = tuple(self.iter_fields(name=True))
+        obj = self
+
+        for name, flag in kwargs.items():
+            if name not in field_names:
+                raise ValueError('{name} not in fields: {field_names}')
+            if not isinstance(flag, bool) and flag is not None:
+                raise ValueError('{name}={flag}, must be bool or None')
+
+            if not flag:
+                if flag is None:
+                    obj = obj.replace(**{name: None})
+                continue
+
+            descr = vars(self.__class__).get(name, None)
+            if isinstance(descr, DataDescriptor):
+                value = descr.run_cache(obj)
+                if value is not obj:
+                    obj = obj.replace(**{name: value})
+
+        return obj
+
+
+def pytree_dataclass(cls, *, frozen=True, **kwargs):
     """Register python dataclasses as custom pytree nodes.
 
-    Also added are methods that return pytree data (dynamic, optional, and fixed) and
-    auxiliary data iterators, pretty string representation, and a method that replace
-    fields with changes.
+    FIXME here and in DataTree
+    Also added are methods that generate pytree data (dynamic and fixed) and auxiliary
+    data iterators, pretty string representation, and a method that replace fields with
+    changes.
+
+    * field or dyn_field marks dynamic pytree children
+    * fxd_field marks fixed pytree children
+    * aux_field marks auxiliary data
+    Data in the dynamic fields (``dyn_field``) are pytree children (``children``), and
+    so are data in the fixed fields but with stopped gradients (``fxd_field``). The
+    auxiliary fields are not for pytree children but some hashable auxiliary data to be
+    stored in the treedef (``aux_data``).
 
     Auxiliary data are static configurations that are not traced by JAX transformations,
     and their hash values are used to cache the transformed functions. Those not marked
@@ -30,11 +492,11 @@ def pytree_dataclass(cls, aux_fields=None, **kwargs):
     ----------
     cls : type
         Class to be registered, not a python dataclass yet.
-    aux_fields : str, iterable of str, or Ellipsis, optional
-        Auxiliary data fields. Default is none; unrecognized ones are ignored;
-        recognized ones must not end with trailing underscores; ``Ellipsis`` uses all.
+    frozen : bool, optional
+        Whether to return a frozen dataclass that emulates read-only behavior. The
+        default has been flipped and you shouldn't need to change this.
     **kwargs
-        Keyword arguments to be passed to python dataclass decorator.
+        Other parameters (except ``frozen``) for the Python dataclass decorator.
 
     Returns
     -------
@@ -43,10 +505,15 @@ def pytree_dataclass(cls, aux_fields=None, **kwargs):
 
     Raises
     ------
-    TypeError
-        If cls is already a python dataclass.
     ValueError
-        If a field name has unexpected trailing underscores.
+        If any field has unrecognized ``ftype`` in metadata.
+
+    Notes
+    -----
+    The pytree nomenclature differs from that of the ordinary tree in its definition of
+    "node": pytree leaves are not pytree nodes in the JAX documentation. The leaves
+    contain data to be traced by JAX transformations, while the nodes are Python
+    (including None) and extended containers to be mapped over.
 
     .. _Augmented dataclass for JAX pytree:
         https://gist.github.com/odashi/813810a5bc06724ea3643456f8d3942d
@@ -54,175 +521,82 @@ def pytree_dataclass(cls, aux_fields=None, **kwargs):
     .. _flax.struct package — Flax documentation:
         https://flax.readthedocs.io/en/latest/flax.struct.html
 
+    .. _Extra features - Equinox:
+        https://docs.kidger.site/equinox/api/module/advanced_fields/
+
+    .. _cgarciae/simple-pytree:
+        https://github.com/cgarciae/simple-pytree
+
     .. _JAX Issue #2371:
         https://github.com/google/jax/issues/2371
 
-    Notes
-    -----
-    The pytree nomenclature differs from that of the ordinary tree in its definition of
-    "node": pytree leaves are not pytree nodes in the JAX documentation. The leaves
-    contain data to be traced by JAX transformations, while the nodes are Python
-    (including None) and extended types to be mapped over.
-
     """
-    if dataclasses.is_dataclass(cls):
-        raise TypeError(f'cls={cls} must not already be a dataclass')
-    cls = dataclasses.dataclass(cls, **kwargs)
+    cls = dataclasses.dataclass(cls, frozen=frozen, **kwargs)
 
-    if aux_fields is None:
-        aux_fields = ()
-    elif isinstance(aux_fields, str):
-        aux_fields = (aux_fields,)
-    elif aux_fields is Ellipsis:
-        aux_fields = tuple(field.name for field in dataclasses.fields(cls))
-
-    dyn_data_names, opt_data_names, fxd_data_names, aux_data_names = [], [], [], []
     for field in dataclasses.fields(cls):
-        name = field.name
-        if name in aux_fields:
-            if name.endswith('_'):
-                raise ValueError(f'{name} must not end with trailing underscore')
-            aux_data_names.append(name)
-        elif name.endswith('___'):
-            raise ValueError(f'{name} with >2 trailing underscores not supported')
-        elif name.endswith('__'):
-            fxd_data_names.append(name)
-        elif name.endswith('_'):
-            opt_data_names.append(name)
-        else:
-            dyn_data_names.append(name)
-    children_names = dyn_data_names + opt_data_names + fxd_data_names
+        if field.metadata.get('ftype', FType.DYNAMIC) not in FType:
+            raise ValueError("unrecognized metadata['ftype']"
+                             f" = {field.metadata['ftype']!r} in field {field.name}")
 
-    def opt_property(name_):
-        @property
-        def foo(self):
-            foo_ = getattr(self, name_)
-            foo__ = getattr(self, name_ + '_')
-            return stop_gradient(foo__) if foo_ is None else foo_
-        return foo
+    def iter_fields(self=None, ftype=FType, name=False, key=False, value=False):
+        """Iterate over field names, keys, and/or values, of given ``ftype``.
 
-    for name_ in opt_data_names:
-        setattr(cls, name_.rstrip('_'), opt_property(name_))
+        Parameters
+        ----------
+        self : DataTree, optional
+            Pytree dataclass instance, ``None`` by default, so that we can get names
+            and/or keys (but not values) without an instance.
+        ftype : FType or its members, optional
+            Pytree dataclass field type to select.
+        name : bool, optional
+            Whether to select field name. It's also possible to get names from keys by
+            ``key.name``.
+        key : bool, optional
+            Whether to select pytree key. It's also possible to get names from keys by
+            ``key.name``.
+        value : bool, optional
+            Whether to select field value.
 
-    def fxd_property(name__):
-        @property
-        def bar(self):
-            bar__ = getattr(self, name__)
-            return stop_gradient(bar__)
-        return bar
+        Raises
+        ------
+        ValueError
+            If none of ``name``, ``key``, or ``value`` is selected, or if selecting
+            ``value`` when ``self is None``.
 
-    for name__ in fxd_data_names:
-        if name__[:-1] not in opt_data_names:
-            setattr(cls, name__.rstrip('_'), fxd_property(name__))
+        """
+        if not name and not key and not value:
+            raise ValueError('must select at least one among name, key, and value')
+        if value and self is None:
+            raise ValueError('values unavailable without an instance')
 
-    def dyn_data_with_keys(self):
-        """Return an iterator over dynamic pytree data with keys."""
-        for name in dyn_data_names:
-            value = getattr(self, name)
-            yield GetAttrKey(name), value
+        for field in dataclasses.fields(cls):
+            if field.metadata.get('ftype', FType.DYNAMIC) in ftype:
+                item = []
+                if name:
+                    item.append(field.name)
+                if key:
+                    item.append(GetAttrKey(field.name))
+                if value:
+                    item.append(getattr(self, field.name))
+                yield tuple(item) if len(item) > 1 else item[0]
+    cls.iter_fields = iter_fields
 
-    def dyn_data(self):
-        """Return an iterator over dynamic pytree data."""
-        for key, value in self.dyn_data_with_keys():
-            yield value
+    def flatten_with_keys(obj):
+        children_with_keys = obj.iter_fields(ftype=FType.CHILD, key=True, value=True)
+        aux_data = obj.iter_fields(ftype=FType.AUXILIARY, value=True)
+        return tuple(children_with_keys), tuple(aux_data)
 
-    def opt_data_with_keys(self):
-        """Return an iterator over optional pytree data with keys."""
-        for name in opt_data_names:
-            value = getattr(self, name)
-            yield GetAttrKey(name), value
+    def flatten_func(obj):
+        children = obj.iter_fields(ftype=FType.CHILD, value=True)
+        aux_data = obj.iter_fields(ftype=FType.AUXILIARY, value=True)
+        return tuple(children), tuple(aux_data)
 
-    def opt_data(self):
-        """Return an iterator over optional pytree data."""
-        for key, value in self.opt_data_with_keys():
-            yield value
-
-    def fxd_data_with_keys(self):
-        """Return an iterator over fixed pytree data with keys."""
-        for name in fxd_data_names:
-            value = getattr(self, name)
-            yield GetAttrKey(name), value
-
-    def fxd_data(self):
-        """Return an iterator over fixed pytree data."""
-        for key, value in self.fxd_data_with_keys():
-            yield value
-
-    def children_with_keys(self):
-        """Return an iterator over all pytree data with keys."""
-        for name in children_names:
-            value = getattr(self, name)
-            yield GetAttrKey(name), value
-
-    def children(self):
-        """Return an iterator over all pytree data."""
-        for key, value in self.children_with_keys():
-            yield value
-
-    def aux_data_with_names(self):
-        """Return an iterator over auxiliary data with names."""
-        for name in aux_data_names:
-            value = getattr(self, name)
-            yield name, value
-
-    def aux_data(self):
-        """Return an iterator over auxiliary data."""
-        for name, value in self.aux_data_with_names():
-            yield value
-
-    cls.dyn_data_with_keys = dyn_data_with_keys
-    cls.dyn_data = dyn_data
-    cls.opt_data_with_keys = opt_data_with_keys
-    cls.opt_data = opt_data
-    cls.fxd_data_with_keys = fxd_data_with_keys
-    cls.fxd_data = fxd_data
-    cls.children_with_keys = children_with_keys
-    cls.children = children
-    cls.aux_data_with_names = aux_data_with_names
-    cls.aux_data = aux_data
-
-    def tree_flatten_with_keys(obj):
-        return list(obj.children_with_keys()), list(obj.aux_data())
-
-    def tree_flatten(obj):
-        return list(obj.children()), list(obj.aux_data())
-
-    def tree_unflatten(aux_data, children):
+    def unflatten_func(aux_data, children):
+        children_names = iter_fields(ftype=FType.CHILD, name=True)
+        aux_data_names = iter_fields(ftype=FType.AUXILIARY, name=True)
         return cls(**dict(zip(children_names, children)),
                    **dict(zip(aux_data_names, aux_data)))
 
-    register_pytree_with_keys(cls, tree_flatten_with_keys, tree_unflatten,
-                              flatten_func=tree_flatten)
-
-    def _is_transforming(self):
-        """Whether dataclass fields are pytrees initialized by JAX transformations.
-
-        .. _Pytrees — JAX documentation:
-            https://jax.readthedocs.io/en/latest/pytrees.html#custom-pytrees-and-initialization
-
-        .. _JAX Issue #10238:
-            https://github.com/google/jax/issues/10238
-
-        """
-        def leaves_all(is_placeholder, tree):
-            # similar to tree_all(tree_map(is_placeholder, tree))
-            return all(is_placeholder(x) for x in tree_leaves(tree))
-
-        # unnecessary to test for None's since they are empty pytree nodes
-        return tree_leaves(self) and leaves_all(lambda x: type(x) is object, self)
-
-    cls._is_transforming = _is_transforming
-
-    def __str__(self):
-        """Pretty string representation for python >= 3.10."""
-        return pformat(self)
-
-    cls.__str__ = __str__
-
-    def replace(self, **changes):
-        """Create a new object of the same type, replacing fields with changes."""
-        return dataclasses.replace(self, **changes)
-
-    cls.replace = replace
+    register_pytree_with_keys(cls, flatten_with_keys, unflatten_func, flatten_func)
 
     return cls

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -144,23 +144,29 @@ def _canonicalize_callables(fun):
 def _call_dual_arity(fun, value, obj):
     """Call as a binary function first and then as a unary function.
 
-    ``fun(value, obj)``, ``fun(value)``, or fail.
+    ``fun(value)``, ``fun(value, obj)``, or fail.
 
     """
-    try:
-        return fun(value, obj)
-    except TypeError as err:
-        err_binary = err
-
     try:
         return fun(value)
     except TypeError as err:
         err_unary = err
 
+    #FIXME encountered a strange bug:
+    # when I put dtype as the first field, and use jnp.dtype to validate, running this
+    # block first results in errors like "Foo objects has no attribute '_bar'", because
+    # in that case fun(value, obj) somehow triggers obj.__len__ which returns
+    # len(self.bar)
+    # so I swapped these 2 blocks, but not sure if the problem still remains
+    try:
+        return fun(value, obj)
+    except TypeError as err:
+        err_binary = err
+
     err = TypeError(f'calling {fun.__qualname__} fails on both binary and unary forms '
                     f'for {value=!r} and {obj=!r}')
-    err.add_note(f'    binary: {err_binary}')
     err.add_note(f'    unary:  {err_unary!r}')
+    err.add_note(f'    binary: {err_binary}')
     raise err
 
 

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -356,7 +356,7 @@ def field(*, mandatory=True, default=None, default_function=None, cache=None,
              validate=None, transform=None, **kwargs):
     """Descriptor dataclass field.
 
-    See `Data` and `dataclasses.field` documentations. For JAX pytrees, use `dyn_field`,
+    See `Data` and `dataclasses.field` documentation. For JAX pytrees, use `dyn_field`,
     `fxd_field`, and `aux_field` instead.
 
     Parameters
@@ -414,7 +414,7 @@ def dyn_field(*, mandatory=True, default=None, default_function=None, cache=None
     `break_on_jax_placeholder` is prepended to `validate` and `transform` to skip on JAX
     transformation placeholders whose `type` is `object`. `dataclasses.Field.metadata`
     is updated with ``'ftype'``. See `Data`, `dataclasses.field`, and JAX pytree
-    documentations.
+    documentation.
 
     Parameters
     ----------
@@ -445,7 +445,7 @@ def fxd_field(*, mandatory=True, default=None, default_function=None, cache=None
     transformation placeholders whose `type` is `object`. `lax.stop_gradient` is
     appended to `transform` if not already in it. `dataclasses.Field.metadata` is
     updated with ``'ftype'``. `repr` is supppressed by default. See `Data`,
-    `dataclasses.field`, and JAX pytree documentations.
+    `dataclasses.field`, and JAX pytree documentation.
 
     Parameters
     ----------
@@ -475,7 +475,7 @@ def aux_field(*, mandatory=True, default=None, default_function=None, cache=None
     """Descriptor dataclass field for pytree auxiliary data, which must be hashable.
 
     `dataclasses.Field.metadata` is updated with ``'ftype'``. `repr` is supppressed by
-    default. See `Data`, `dataclasses.field`, and JAX pytree documentations.
+    default. See `Data`, `dataclasses.field`, and JAX pytree documentation.
 
     Parameters
     ----------
@@ -639,7 +639,7 @@ class TanMixin:
         return tree_map(partial(scalar_div, scalar), self)
 
 
-def pytree_dataclass(cls, *, frozen=True, **kwargs):
+def pytree_dataclass(cls, *, frozen=True, kw_only=True, **kwargs):
     """Register classes as dataclasses and pytree nodes.
 
     `iter_fields` is implemented to iterate over fields of selected pytree dataclass
@@ -653,8 +653,10 @@ def pytree_dataclass(cls, *, frozen=True, **kwargs):
     frozen : bool, optional
         Whether to return a frozen dataclass that emulates read-only behavior, frozen by
         default which one shouldn't need to change.
+    kw_only : bool, optional
+        Whether to mark all fields as keyword-only, flipped to true by default.
     **kwargs
-        Other parameters besides `frozen` for the `dataclasses.dataclass`.
+        Other parameters besides `frozen` and `kw_only` for the `dataclasses.dataclass`.
 
     Returns
     -------
@@ -699,16 +701,16 @@ def pytree_dataclass(cls, *, frozen=True, **kwargs):
     ...                                  repr=True)
     ...     theta: ArrayLike = dyn_field(default=jnp.array([0, 1, 1j]),
     ...                                  validate=asarray_of(field='dtype'))
-    ...     const: ArrayLike = fxd_field(default=jnp.array([2.7182818, 3.1415926]),
+    ...     const: ArrayLike = fxd_field(default=jnp.array([2.71828, 3.14159]),
     ...                                  validate=jnp.float32,
     ...                                  repr=True)
     >>> print(Parameters())
     Parameters(dtype=<class 'jax.numpy.complex64'>,
                theta=Array([0.+0.j, 1.+0.j, 0.+1.j], dtype=complex64),
-               const=Array([2.7182817, 3.1415925], dtype=float32))
+               const=Array([2.71828, 3.14159], dtype=float32))
 
     """
-    cls = dataclasses.dataclass(cls, frozen=frozen, **kwargs)
+    cls = dataclasses.dataclass(cls, frozen=frozen, kw_only=kw_only, **kwargs)
 
     for field in dataclasses.fields(cls):
         if field.metadata.get('ftype', FType.DYNAMIC) not in FType:

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -179,9 +179,9 @@ class Data:
 
     Parameters
     ----------
-    mandatory : bool, optional
-        Whether the value must be initialized to something other than `None`, if none of
-        `default`, `default_function`, or `cache` is specified.
+    optional : bool, optional
+        Whether the initialized value can be `None`, if none of `default`,
+        `default_function`, or `cache` is specified.
     default : pytree, optional
         Default value.
     default_function : callable or None, optional
@@ -205,7 +205,7 @@ class Data:
     ------
     ValueError
         If more than one is specified among `default`, `default_function`, and `cache`,
-        or if mandatory data is missing when none of the three is specified.
+        or if mandatory (``optional=False``) but none of them is specified.
     TypeError
         If trying to set or delete descriptor attributes.
 
@@ -235,7 +235,7 @@ class Data:
     """
 
     __slots__ = (
-        'mandatory',
+        'optional',
         'default',
         'default_function',
         'cache',
@@ -246,7 +246,7 @@ class Data:
         '_name',
     )
 
-    def __init__(self, mandatory=True, default=None, default_function=None, cache=None,
+    def __init__(self, optional=False, default=None, default_function=None, cache=None,
                  validate=None, transform=None):
         if sum(x is not None for x in (default, default_function, cache)) > 1:
             raise ValueError(f'{default=}, {default_function=}, and {cache=} are '
@@ -255,7 +255,7 @@ class Data:
         validate = _canonicalize_callables(validate)
         transform = _canonicalize_callables(transform)
 
-        object.__setattr__(self, 'mandatory', mandatory)
+        object.__setattr__(self, 'optional', optional)
         object.__setattr__(self, 'default', default)
         object.__setattr__(self, 'default_function', default_function)
         object.__setattr__(self, 'cache', cache)
@@ -265,7 +265,7 @@ class Data:
     def __repr__(self):
         return (
             f'{type(self).__qualname__}(\n'
-            f'    mandatory={self.mandatory!r},\n'
+            f'    optional={self.optional!r},\n'
             f'    default={self.default!r},\n'
             f'    default_function={self.default_function!r},\n'
             f'    cache={self.cache!r},\n'
@@ -315,7 +315,7 @@ class Data:
 
     def raise_missing(self, obj):
         """Raise if mandatory but missing."""
-        if self.mandatory and all(x is None for x in (
+        if not self.optional and all(x is None for x in (
                 self.default, self.default_function, self.cache, self.__get__(obj))):
             raise ValueError(f'mandatory data {self.name} missing for '
                              f'{self.objtype.__qualname__}')
@@ -357,7 +357,7 @@ class Data:
         return value
 
 
-def field(*, mandatory=True, default=None, default_function=None, cache=None,
+def field(*, optional=False, default=None, default_function=None, cache=None,
              validate=None, transform=None, **kwargs):
     """Descriptor dataclass field.
 
@@ -372,7 +372,7 @@ def field(*, mandatory=True, default=None, default_function=None, cache=None,
 
     """
     return dataclasses.field(
-        default=Data(mandatory, default, default_function, cache, validate, transform),
+        default=Data(optional, default, default_function, cache, validate, transform),
         **kwargs,
     )
 
@@ -412,7 +412,7 @@ def _update_metadata(kwargs, ftype):
     return kwargs
 
 
-def dyn_field(*, mandatory=True, default=None, default_function=None, cache=None,
+def dyn_field(*, optional=False, default=None, default_function=None, cache=None,
               validate=None, transform=None, **kwargs):
     """Descriptor dataclass field for dynamic pytree children.
 
@@ -437,12 +437,12 @@ def dyn_field(*, mandatory=True, default=None, default_function=None, cache=None
     kwargs = _update_metadata(kwargs, FType.DYNAMIC)
 
     return dataclasses.field(
-        default=Data(mandatory, default, default_function, cache, validate, transform),
+        default=Data(optional, default, default_function, cache, validate, transform),
         **kwargs,
     )
 
 
-def fxd_field(*, mandatory=True, default=None, default_function=None, cache=None,
+def fxd_field(*, optional=False, default=None, default_function=None, cache=None,
               validate=None, transform=lax.stop_gradient, repr=False, **kwargs):
     """Descriptor dataclass field for fixed pytree children.
 
@@ -470,12 +470,12 @@ def fxd_field(*, mandatory=True, default=None, default_function=None, cache=None
     kwargs = _update_metadata(kwargs, FType.FIXED)
 
     return dataclasses.field(
-        default=Data(mandatory, default, default_function, cache, validate, transform),
+        default=Data(optional, default, default_function, cache, validate, transform),
         repr=repr, **kwargs,
     )
 
 
-def aux_field(*, mandatory=True, default=None, default_function=None, cache=None,
+def aux_field(*, optional=False, default=None, default_function=None, cache=None,
               validate=None, transform=None, repr=False, **kwargs):
     """Descriptor dataclass field for pytree auxiliary data, which must be hashable.
 
@@ -492,7 +492,7 @@ def aux_field(*, mandatory=True, default=None, default_function=None, cache=None
     kwargs = _update_metadata(kwargs, FType.AUXILIARY)
 
     return dataclasses.field(
-        default=Data(mandatory, default, default_function, cache, validate, transform),
+        default=Data(optional, default, default_function, cache, validate, transform),
         repr=repr, **kwargs,
     )
 

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -25,7 +25,7 @@ from pmwd.util import add, sub, neg, scalar_mul, scalar_div
 
 # TODO add serialization to zarr https://docs.xarray.dev/en/latest/user-guide/io.html#zarr
 # TODO https://docs.python.org/3/library/json.html extend encoder and decoder, as zarr uses json
-# TODO tensorstore is probably better
+# TODO better to use orbax [=> tensorstore [=> zarr]], which supports pytrees
 
 
 def issubdtype_of(stype):
@@ -141,7 +141,7 @@ def _canonicalize_callables(fun):
 
 
 def _call_dual_arity(fun, value, obj):
-    """Call as a binary function first and then as a unary function.
+    """Call as a unary function first and then as a binary function.
 
     ``fun(value)``, ``fun(value, obj)``, or fail.
 
@@ -180,14 +180,14 @@ class Data:
     Parameters
     ----------
     optional : bool, optional
-        Whether the initialized value can be `None`, if none of `default`,
-        `default_function`, or `cache` is specified.
+        Whether the initialized value can be `None`, if none of `default`, `depend`, or
+        `cache` is specified.
     default : pytree, optional
         Default value.
-    default_function : callable or None, optional
-        Default function to compute the value, if not already initialized to anything
-        else but `None`, from the instance of the owner class, ``value =
-        default_function(obj)``, runned by, e.g., `Tree.__post_init__`.
+    depend : callable or None, optional
+        Functional dependency to determine the value, if not already initialized to
+        anything else but `None`, from the instance of the owner class, ``value =
+        depend(obj)``, runned by, e.g., `Tree.__post_init__`.
     cache : callable or None, optional
         Caching function to compute the value from the instance of the owner class,
         ``value = cache(obj)``, runned by, e.g., `Tree.cache`.
@@ -204,8 +204,8 @@ class Data:
     Raises
     ------
     ValueError
-        If more than one is specified among `default`, `default_function`, and `cache`,
-        or if mandatory (``optional=False``) but none of them is specified.
+        If more than one is specified among `default`, `depend`, and `cache`, or if
+        mandatory (``optional=False``) but none of them is specified.
     TypeError
         If trying to set or delete descriptor attributes.
 
@@ -237,7 +237,7 @@ class Data:
     __slots__ = (
         'optional',
         'default',
-        'default_function',
+        'depend',
         'cache',
         'validate',
         'transform',
@@ -246,18 +246,18 @@ class Data:
         '_name',
     )
 
-    def __init__(self, optional=False, default=None, default_function=None, cache=None,
+    def __init__(self, optional=False, default=None, depend=None, cache=None,
                  validate=None, transform=None):
-        if sum(x is not None for x in (default, default_function, cache)) > 1:
-            raise ValueError(f'{default=}, {default_function=}, and {cache=} are '
-                             'mutually exclusive')
+        if sum(x is not None for x in (default, depend, cache)) > 1:
+            raise ValueError(f'{default=}, {depend=}, and {cache=} are mutually'
+                             'exclusive')
 
         validate = _canonicalize_callables(validate)
         transform = _canonicalize_callables(transform)
 
         object.__setattr__(self, 'optional', optional)
         object.__setattr__(self, 'default', default)
-        object.__setattr__(self, 'default_function', default_function)
+        object.__setattr__(self, 'depend', depend)
         object.__setattr__(self, 'cache', cache)
         object.__setattr__(self, 'validate', validate)
         object.__setattr__(self, 'transform', transform)
@@ -267,7 +267,7 @@ class Data:
             f'{type(self).__qualname__}(\n'
             f'    optional={self.optional!r},\n'
             f'    default={self.default!r},\n'
-            f'    default_function={self.default_function!r},\n'
+            f'    depend={self.depend!r},\n'
             f'    cache={self.cache!r},\n'
             f'    validate={pformat(repr(self.validate))},\n'
             f'    transform={pformat(repr(self.transform))},\n'
@@ -316,15 +316,15 @@ class Data:
     def raise_missing(self, obj):
         """Raise if mandatory but missing."""
         if not self.optional and all(x is None for x in (
-                self.default, self.default_function, self.cache, self.__get__(obj))):
+                self.default, self.depend, self.cache, self.__get__(obj))):
             raise ValueError(f'mandatory data {self.name} missing for '
                              f'{self.objtype.__qualname__}')
 
-    def run_default_function(self, obj):
-        """Run default function."""
-        if self.default_function is None or self.__get__(obj) is not None:
+    def run_depend(self, obj):
+        """Run functional dependency."""
+        if self.depend is None or self.__get__(obj) is not None:
             return obj
-        value = self.default_function(obj)
+        value = self.depend(obj)
         return value
 
     def run_cache(self, obj):
@@ -357,8 +357,8 @@ class Data:
         return value
 
 
-def field(*, optional=False, default=None, default_function=None, cache=None,
-             validate=None, transform=None, **kwargs):
+def field(*, optional=False, default=None, depend=None, cache=None, validate=None,
+          transform=None, **kwargs):
     """Descriptor dataclass field.
 
     See `Data` and `dataclasses.field` documentation. For JAX pytrees, use `dyn_field`,
@@ -372,7 +372,7 @@ def field(*, optional=False, default=None, default_function=None, cache=None,
 
     """
     return dataclasses.field(
-        default=Data(optional, default, default_function, cache, validate, transform),
+        default=Data(optional, default, depend, cache, validate, transform),
         **kwargs,
     )
 
@@ -412,8 +412,8 @@ def _update_metadata(kwargs, ftype):
     return kwargs
 
 
-def dyn_field(*, optional=False, default=None, default_function=None, cache=None,
-              validate=None, transform=None, **kwargs):
+def dyn_field(*, optional=False, default=None, depend=None, cache=None, validate=None,
+              transform=None, **kwargs):
     """Descriptor dataclass field for dynamic pytree children.
 
     `break_on_jax_placeholder` is prepended to `validate` and `transform` to skip on JAX
@@ -437,13 +437,13 @@ def dyn_field(*, optional=False, default=None, default_function=None, cache=None
     kwargs = _update_metadata(kwargs, FType.DYNAMIC)
 
     return dataclasses.field(
-        default=Data(optional, default, default_function, cache, validate, transform),
+        default=Data(optional, default, depend, cache, validate, transform),
         **kwargs,
     )
 
 
-def fxd_field(*, optional=False, default=None, default_function=None, cache=None,
-              validate=None, transform=lax.stop_gradient, repr=False, **kwargs):
+def fxd_field(*, optional=False, default=None, depend=None, cache=None, validate=None,
+              transform=lax.stop_gradient, repr=False, **kwargs):
     """Descriptor dataclass field for fixed pytree children.
 
     `break_on_jax_placeholder` is prepended to `validate` and `transform` to skip on JAX
@@ -470,13 +470,13 @@ def fxd_field(*, optional=False, default=None, default_function=None, cache=None
     kwargs = _update_metadata(kwargs, FType.FIXED)
 
     return dataclasses.field(
-        default=Data(optional, default, default_function, cache, validate, transform),
+        default=Data(optional, default, depend, cache, validate, transform),
         repr=repr, **kwargs,
     )
 
 
-def aux_field(*, optional=False, default=None, default_function=None, cache=None,
-              validate=None, transform=None, repr=False, **kwargs):
+def aux_field(*, optional=False, default=None, depend=None, cache=None, validate=None,
+              transform=None, repr=False, **kwargs):
     """Descriptor dataclass field for pytree auxiliary data, which must be hashable.
 
     `dataclasses.Field.metadata` is updated with ``'ftype'``. `repr` is supppressed by
@@ -492,7 +492,7 @@ def aux_field(*, optional=False, default=None, default_function=None, cache=None
     kwargs = _update_metadata(kwargs, FType.AUXILIARY)
 
     return dataclasses.field(
-        default=Data(optional, default, default_function, cache, validate, transform),
+        default=Data(optional, default, depend, cache, validate, transform),
         repr=repr, **kwargs,
     )
 
@@ -503,9 +503,9 @@ class Tree:
 
     Use it together with either `dataclasses.dataclass` or `pytree_dataclass`.
     `dataclasses.__post_init__` is implemented to check missing mandatory arguments, and
-    to compute and fill values using `Data.default_function`. Also added are pretty
-    string by `pprint.pformat`, a method that `replace` fields with changes, and methods
-    to `cache` and `purge` fields.
+    to compute and fill values using `Data.depend`. Also added are pretty string by
+    `pprint.pformat`, a method that `replace` fields with changes, and methods to
+    `cache` and `purge` fields.
 
     Raises
     ------
@@ -521,8 +521,9 @@ class Tree:
     ...     i: complex = Data(default=1j, validate=complex)
     ...     one: complex = Data(default=1, validate=complex)
     ...     zero: complex = Data(
-    ...         default_function=lambda self: self.e ** (self.i * self.pi) + self.one,
-    ...         validate=(abs, float, lambda value: round(value, ndigits=5), complex))
+    ...         depend=lambda self: self.e ** (self.i * self.pi) + self.one,
+    ...         validate=(abs, float, lambda value: round(value, ndigits=5), complex),
+    ...     )
     >>> print(Euler())
     Euler(e=2.7182818, pi=3.1415926, i=1j, one==(1+0j), zero=0j)
 
@@ -552,7 +553,7 @@ class Tree:
 
                 descr.raise_missing(self)
 
-                value = descr.run_default_function(self)
+                value = descr.run_depend(self)
                 if value is not self:
                     descr.__set__(self, value)
 
@@ -633,12 +634,18 @@ class TanMixin:
         return tree_map(neg, self)
 
     def __mul__(self, scalar):
+        #commented out as maybe one will want to broadcast here one day
+        #if not jnp.isscalar(scalar):
+        #    raise TypeError(f'{scalar} not a scalar for scalar multiplication')
         return tree_map(partial(scalar_mul, scalar), self)
 
     def __rmul__(self, scalar):
         return self.__mul__(scalar)
 
     def __truediv__(self, scalar):
+        #commented out as maybe one will want to broadcast here one day
+        #if not jnp.isscalar(scalar):
+        #    raise TypeError(f'{scalar} not a scalar for scalar division')
         return tree_map(partial(scalar_div, scalar), self)
 
 
@@ -675,8 +682,8 @@ def pytree_dataclass(cls, *, frozen=True, kw_only=True, **kwargs):
     -----
     The pytree nomenclature differs from that of the ordinary tree in its definition of
     "node": pytree leaves are not pytree nodes in the JAX documentation. The leaves
-    contain data to be traced by JAX transformations, while the nodes are Python
-    (including None) and extended containers to be mapped over.
+    contain data to be traced by JAX transformations, while the nodes are standard
+    (including None as empty node) and custom containers to be mapped over.
 
     References
     ----------

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -1,4 +1,3 @@
-from abc import ABC, abstractmethod
 from collections.abc import Callable
 import dataclasses
 from enum import Flag, auto
@@ -498,7 +497,7 @@ def aux_field(*, mandatory=True, default=None, default_function=None, cache=None
     )
 
 
-class Tree(ABC):
+class Tree:
     """Base class for combining `Data`, `dataclasses.dataclass`, and optionally JAX
     pytree.
 
@@ -511,7 +510,7 @@ class Tree(ABC):
     Raises
     ------
     TypeError
-        If not a `dataclasses.dataclass` at instance creation.
+        If directly instantiated, or not a `dataclasses.dataclass` at instance creation.
 
     Examples
     --------
@@ -532,13 +531,11 @@ class Tree(ABC):
     """
 
     def __new__(cls, *args, **kwargs):
+        if cls is Tree:
+            raise TypeError(f'subclass, do not instantiate, the base {cls.__name__}')
         if not dataclasses.is_dataclass(cls):
             raise TypeError(f'{cls.__qualname__} must be a dataclasses.dataclass')
         return super().__new__(cls)
-
-    @abstractmethod
-    def __init__(self, *args, **kwargs):
-        pass
 
     def __str__(self):
         return pformat(self)  # python >= 3.10

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 import dataclasses
 from enum import Flag, auto
 from functools import partial
+from operator import itemgetter
 from pprint import pformat
 
 import jax.numpy as jnp
@@ -46,16 +47,59 @@ def issubdtype_of(stype):
     return fun
 
 
-def asarray_of(dtype=None, field=None):
-    """Return a validator function that casts the children of its input pytree to JAX
-    arrays of the specified dtype.
+def asarray_of(dtype=None, field=None, recur=False):
+    """Return a validator function that casts its input to JAX arrays of the specified
+    dtype.
 
     Parameters
     ----------
     dtype : DTypeLike, optional
-        `dtype` can be `None`, `float`, or `int`, while more specific conversions can be
-        done using, e.g., `validate=jnp.float32` instead of the more cumbersome
-        ``validate=asarray_of(dtype=jnp.float32)``.
+        `dtype` can be `None`, `float`, or `int`, while more specific conversions of an
+        `ArrayLike` can be done using, e.g., `validate=jnp.float32` instead of the more
+        cumbersome ``validate=asarray_of(dtype=jnp.float32)``.
+    field : str, optional
+        If not `None`, use dtype inferred from `field` of the owner dataclass, which can
+        be either a `DTypeLike` or an `Array`.
+    recur : bool, optional
+        Whether to operate recursively, taking the input as a pytree instead of an
+        `ArrayLike`.
+
+    Raises
+    ------
+    ValueError
+        If both `dtype` and `field` are not `None`.
+
+    """
+    if field is None:
+        if recur:
+            def fun(value):
+                return tree_map(partial(jnp.asarray, dtype=dtype), value)
+        else:
+            def fun(value):
+                return jnp.asarray(value, dtype=dtype)
+        return fun
+
+    if dtype is not None:
+        raise ValueError('dtype and field are mutually exclusive')
+
+    if recur:
+        def fun(value, obj):
+            dtype = jnp.dtype(getattr(obj, field))
+            return tree_map(partial(jnp.asarray, dtype=dtype), value)
+    else:
+        def fun(value, obj):
+            dtype = jnp.dtype(getattr(obj, field))
+            return jnp.asarray(value, dtype=dtype)
+    return fun
+
+
+def astype_of(dtype=None, field=None):
+    """Return a validator function that calls the `astype` method of its input pytree
+    with the specified dtype.
+
+    Parameters
+    ----------
+    dtype : DTypeLike, optional
     field : str, optional
         If not `None`, use dtype inferred from `field` of the owner dataclass, which can
         be either a `DTypeLike` or an `Array`.
@@ -68,7 +112,7 @@ def asarray_of(dtype=None, field=None):
     """
     if field is None:
         def fun(value):
-            return tree_map(partial(jnp.asarray, dtype=dtype), value)
+            return value.astype(dtype)
         return fun
 
     if dtype is not None:
@@ -76,13 +120,13 @@ def asarray_of(dtype=None, field=None):
 
     def fun(value, obj):
         dtype = jnp.dtype(getattr(obj, field))
-        return tree_map(partial(jnp.asarray, dtype=dtype), value)
+        return value.astype(dtype)
     return fun
 
 
-def reshape_to(shape=None, field=None):
-    """Return a validator function that reshapes the children of its input pytree to the
-    specified shape.
+def reshape_to(shape=None, field=None, recur=False):
+    """Return a validator function that reshapes its input arrays to the specified
+    shape.
 
     Parameters
     ----------
@@ -90,6 +134,9 @@ def reshape_to(shape=None, field=None):
     field : str, optional
         If not `None`, use shape inferred from `field` of the owner dataclass, which can
         be either a `tuple` or an `Array`.
+    recur : bool, optional
+        Whether to operate recursively, taking the input as a pytree instead of an
+        array.
 
     Raises
     ------
@@ -98,31 +145,44 @@ def reshape_to(shape=None, field=None):
 
     """
     if field is None:
-        def fun(value):
-            return tree_map(partial(jnp.reshape, shape=shape), value)
+        if recur:
+            def fun(value):
+                return tree_map(partial(jnp.reshape, shape=shape), value)
+        else:
+            def fun(value):
+                return jnp.reshape(value, shape=shape)
         return fun
 
     if shape is not None:
         raise ValueError('shape and field are mutually exclusive')
 
-    def fun(value, obj):
-        shape = getattr(obj, field)
-        shape = shape.shape if isinstance(shape, Array) else shape
-        return tree_map(partial(jnp.reshape, shape=shape), value)
+    if recur:
+        def fun(value, obj):
+            shape = getattr(obj, field)
+            shape = shape.shape if isinstance(shape, Array) else shape
+            return tree_map(partial(jnp.reshape, shape=shape), value)
+    else:
+        def fun(value, obj):
+            shape = getattr(obj, field)
+            shape = shape.shape if isinstance(shape, Array) else shape
+            return jnp.reshape(value, shape=shape)
     return fun
 
 
 def wrap_around(modulus):
-    """Return a validator function that wraps the children of its input pytree around
-    the specified modulus.
+    """Return a validator function that wraps its input around the specified modulus.
 
     Parameters
     ----------
     modulus : int or float ArrayLike
 
+    Notes
+    -----
+    This can also wrap the gradients and cause problems.
+
     """
     def fun(value):
-        return tree_map(lambda x: x % modulus, value)
+        return value % modulus
     return fun
 
 
@@ -141,11 +201,7 @@ def _canonicalize_callables(fun):
 
 
 def _call_dual_arity(fun, value, obj):
-    """Call as a unary function first and then as a binary function.
-
-    ``fun(value)``, ``fun(value, obj)``, or fail.
-
-    """
+    """Call as a unary function first and then as a binary function, returning ``fun(value)``, ``fun(value, obj)``, or raise."""
     try:
         return fun(value)
     except TypeError as err:
@@ -163,7 +219,7 @@ def _call_dual_arity(fun, value, obj):
         err_binary = err
 
     err = TypeError(f'calling {fun.__qualname__} fails on both binary and unary forms '
-                    f'for {value=!r} and {obj=!r}')
+                    f'for {value=!r} and {type(obj)=}')
     err.add_note(f'    unary:  {err_unary!r}')
     err.add_note(f'    binary: {err_binary}')
     raise err
@@ -319,20 +375,6 @@ class Data:
                 self.default, self.depend, self.cache, self.__get__(obj))):
             raise ValueError(f'mandatory data {self.name} missing for '
                              f'{self.objtype.__qualname__}')
-
-    def run_depend(self, obj):
-        """Run functional dependency."""
-        if self.depend is None or self.__get__(obj) is not None:
-            return obj
-        value = self.depend(obj)
-        return value
-
-    def run_cache(self, obj):
-        """Run caching function."""
-        if self.cache is None:
-            return obj
-        value = self.cache(obj)
-        return value
 
     def run_validate(self, value, obj):
         """Run validator functions."""
@@ -554,8 +596,8 @@ class Tree:
 
                 descr.raise_missing(self)
 
-                value = descr.run_depend(self)
-                if value is not self:
+                if descr.depend is not None and descr.__get__(self) is None:
+                    value = descr.depend(self)
                     descr.__set__(self, value)
 
     #TODO warn reserved member names replace, cache, & purge. How?
@@ -567,15 +609,29 @@ class Tree:
         """
         return dataclasses.replace(self, **changes)
 
-    def cache(self, *args):
-        """Cache specified fields in the order of `args`, ignoring absent or non-caching
-        ones.
+    #TODO: caching multiple fields by one function
+    #    *args  # enhancing args
+    #        ... Each string can include multiple fields separated by commas to cache them
+    #        together by the same function, e.g., ``obj.cache('x, y, z')``. The caching
+    #        functions of the first fields are used, and `Ellipsis` can be used as
+    #        placeholders in those of the other fields.  #TODO allow ... for this usage
+    #        The assignments of the returned values assume the same orders.
+    #    **kwargs  # enhancing kwargs
+    #        Names-arguments pairs also passing and unpacking iterables of other
+    #        arguments after `self` into the cache functions, e.g., ``obj.cache(**{'x, y,
+    #        z': (a, b, c)})``. See also the `args` above.
+    def cache(self, *args, **kwargs):
+        """Cache specified fields in the order of `args` and then `kwargs`, ignoring
+        absent or non-caching ones.
 
         Parameters
         ----------
-        args
+        *args
             Names of the fields to cache. Pass a single `...` to cache all fields in the
             order of `dataclasses.fields`.
+        **kwargs
+            Name-iterable pairs also passing and unpacking iterables of other arguments
+            after `self` into the cache functions.
 
         Returns
         -------
@@ -588,10 +644,14 @@ class Tree:
         obj = self
         for name in args:
             descr = vars(type(self)).get(name, None)
-            if isinstance(descr, Data):
-                value = descr.run_cache(obj)
-                if value is not obj:
-                    obj = obj.replace(**{name: value})
+            if isinstance(descr, Data) and descr.cache is not None:
+                value = descr.cache(obj)
+                obj = obj.replace(**{name: value})
+        for name, objs in kwargs.items():
+            descr = vars(type(self)).get(name, None)
+            if isinstance(descr, Data) and descr.cache is not None:
+                value = descr.cache(obj, *objs)
+                obj = obj.replace(**{name: value})
         return obj
 
     def purge(self, *args):
@@ -599,7 +659,7 @@ class Tree:
 
         Parameters
         ----------
-        args
+        *args
             Names of the fields to purge. Pass a single `...` to purge all fields.
 
         Returns
@@ -618,6 +678,7 @@ class Tree:
         return obj
 
 
+# TODO  DTypeMixin (dtype, astype, asarray_of, astype_of), SeqMixin (getitem), StoreMixin ("serialize"), PhysMixin (M, L, T, const)
 # TODO maybe move this and add, sub, etc to something like tan.py
 class TanMixin:
     """Addition and scalar multiplication operations for tangent and cotangent vector
@@ -793,3 +854,14 @@ def pytree_dataclass(cls, *, frozen=True, kw_only=True, **kwargs):
     register_pytree_with_keys(cls, flatten_with_keys, unflatten_func, flatten_func)
 
     return cls
+
+
+def getitem(pytree, k):
+    """Select or slice all the pytree children."""
+    return tree_map(itemgetter(k), pytree)
+
+
+def concatenate(*pytrees, axis=0):
+    """Concatenate all the corresponding children of all the pytrees. See documentation
+    of `jax.numpy.concatenate` for array concatenation."""
+    return tree_map(lambda *arrays: jnp.concatenate(arrays, axis=axis), *pytrees)

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -113,6 +113,20 @@ def reshape_to(shape=None, field=None):
     return fun
 
 
+def wrap_around(modulus):
+    """Return a validator function that wraps the children of its input pytree around
+    the specified modulus.
+
+    Parameters
+    ----------
+    modulus : int or float ArrayLike
+
+    """
+    def fun(value):
+        return tree_map(lambda x: x % modulus, value)
+    return fun
+
+
 # TODO get inspirations from attrs, cattrs, pydantic, traitlets, marshmallow, schematics
 
 

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -398,6 +398,7 @@ class FType(Flag):
     FIXED = auto()
     AUXILIARY = auto()
     CHILD = DYNAMIC | FIXED
+
 FType.DYNAMIC.__doc__ = 'Dynamic pytree children with gradients.'
 FType.FIXED.__doc__ = 'Fixed pytree children without gradients.'
 FType.CHILD.__doc__ = 'Pytree children, dynamic or fixed.'
@@ -735,7 +736,7 @@ def pytree_dataclass(cls, *, frozen=True, kw_only=True, **kwargs):
         self : Tree, optional
             Pytree dataclass object, `None` by default, so that we can get names and/or
             keys (but not values) without an object.
-        ftype : FType or its members, optional
+        ftype : FType, its members, or case-insensitive str, optional
             Pytree dataclass field type to select.
         name : bool, optional
             Whether to select field name. It's also possible to get names from keys by
@@ -757,6 +758,9 @@ def pytree_dataclass(cls, *, frozen=True, kw_only=True, **kwargs):
             raise ValueError('must select at least one among name, key, and value')
         if value and self is None:
             raise ValueError('values unavailable without a pytree dataclass object')
+
+        if isinstance(ftype, str):
+            ftype = FType[ftype.upper()]
 
         for field in dataclasses.fields(cls):
             if field.metadata.get('ftype', FType.DYNAMIC) in ftype:

--- a/pmwd/tree_util.py
+++ b/pmwd/tree_util.py
@@ -6,7 +6,7 @@ from functools import partial
 from pprint import pformat
 
 import jax.numpy as jnp
-from jax import lax
+from jax import Array, lax
 from jax.tree_util import GetAttrKey, register_pytree_with_keys, tree_leaves, tree_map
 
 from pmwd.util import add, sub, neg, scalar_mul, scalar_div
@@ -29,27 +29,42 @@ from pmwd.util import add, sub, neg, scalar_mul, scalar_div
 # TODO tensorstore is probably better
 
 
-def issubdtype_of(dtype):
-    """Return a function that raises `ValueError` if input object is not equal or lower
-    than specified `dtype`.
+def issubdtype_of(stype):
+    """Return a validator function that raises `ValueError` if its input object is not
+    equal or lower than the specified scalar type.
 
-    Useful for validation in `Data`.
+    Parameters
+    ----------
+    stype : scalar type
+        ``jnp.number``, ``jnp.integer``, ``jnp.signedinteger``, ``jnp.unsignedinteger``,
+        ``jnp.inexact``, ``jnp.floating``, ``jnp.complexfloating``, or ``jnp.bool``.
 
     """
     def fun(value):
-        if not jnp.issubdtype(value, dtype):
-            raise ValueError(f'{obj!r} must be sub-dtype of {dtype!r}')
+        if not jnp.issubdtype(value, stype):
+            raise ValueError(f'{obj!r} must be sub-dtype of {stype!r}')
         return value
     return fun
 
 
 def asarray_of(dtype=None, field=None):
-    """Return a function that converts input pytree children to JAX arrays of specified
-    `dtype`, or dtype given by the specified `field` of pytree dataclass.
+    """Return a validator function that casts the children of its input pytree to JAX
+    arrays of the specified dtype.
 
-    Useful for validation in `Data`. `dtype` can be `None` or `float`, while more
-    specific conversions can be done using e.g. `jnp.float32` instead of
-    ``asarray_of(dtype=jnp.float32)``.
+    Parameters
+    ----------
+    dtype : DTypeLike, optional
+        `dtype` can be `None`, `float`, or `int`, while more specific conversions can be
+        done using, e.g., `validate=jnp.float32` instead of the more cumbersome
+        ``validate=asarray_of(dtype=jnp.float32)``.
+    field : str, optional
+        If not `None`, use dtype inferred from `field` of the owner dataclass, which can
+        be either a `DTypeLike` or an `Array`.
+
+    Raises
+    ------
+    ValueError
+        If both `dtype` and `field` are not `None`.
 
     """
     if field is None:
@@ -61,21 +76,26 @@ def asarray_of(dtype=None, field=None):
         raise ValueError('dtype and field are mutually exclusive')
 
     def fun(value, obj):
-        # FIXME are these line necessary/useful? this uses treemap and jnp anyway?
-        #if not hasattr(obj, 'iter_fields'):
-        #    raise TypeError(f'{obj=} not a pytree dataclass')
-        #if field not in obj.iter_fields(ftype=FType.AUXILIARY, name=True):
-        #    raise ValueError(f'{field=} not in auxiliary fields of {obj=}')
-        dtype = getattr(obj, field)
+        dtype = jnp.dtype(getattr(obj, field))
         return tree_map(partial(jnp.asarray, dtype=dtype), value)
     return fun
 
 
 def reshape_to(shape=None, field=None):
-    """Return a function that reshapes input pytree children to specified `shape`, or
-    shape given by the specified `field` of pytree dataclass.
+    """Return a validator function that reshapes the children of its input pytree to the
+    specified shape.
 
-    Useful for validation in `Data`.
+    Parameters
+    ----------
+    shape : tuple, optional
+    field : str, optional
+        If not `None`, use shape inferred from `field` of the owner dataclass, which can
+        be either a `tuple` or an `Array`.
+
+    Raises
+    ------
+    ValueError
+        If both `shape` and `field` are not `None`.
 
     """
     if field is None:
@@ -87,12 +107,8 @@ def reshape_to(shape=None, field=None):
         raise ValueError('shape and field are mutually exclusive')
 
     def fun(value, obj):
-        # FIXME are these line necessary/useful? this uses treemap and jnp anyway?
-        #if not hasattr(obj, iter_fields):
-        #    raise TypeError(f'{obj=} not a pytree dataclass')
-        #if field not in obj.iter_fields(ftype=FType.AUXILIARY, name=True):
-        #    raise ValueError(f'{field=} not in auxiliary fields of {obj=}')
         shape = getattr(obj, field)
+        shape = shape.shape if isinstance(shape, Array) else shape
         return tree_map(partial(jnp.reshape, shape=shape), value)
     return fun
 
@@ -152,10 +168,10 @@ class Data:
     default_function : callable or None, optional
         Default function to compute the value, if not already initialized to anything
         else but `None`, from the instance of the owner class, ``value =
-        default_function(obj)``, runned by e.g. `Tree.__post_init__`.
+        default_function(obj)``, runned by, e.g., `Tree.__post_init__`.
     cache : callable or None, optional
         Caching function to compute the value from the instance of the owner class,
-        ``value = cache(obj)``, runned by e.g. `Tree.cache`.
+        ``value = cache(obj)``, runned by, e.g., `Tree.cache`.
     validate : callable, sequence of callable, or None, optional
         Validator functions before setting the value, ``value = fun(value)`` or ``value
         = fun(value, obj)``. Skipped if input ``value is None``. If a sequence, apply
@@ -282,7 +298,7 @@ class Data:
         """Raise if mandatory but missing."""
         if self.mandatory and all(x is None for x in (
                 self.default, self.default_function, self.cache, self.__get__(obj))):
-            raise ValueError(f'mandatory {self.name} missing for '
+            raise ValueError(f'mandatory data {self.name} missing for '
                              f'{self.objtype.__qualname__}')
 
     def run_default_function(self, obj):
@@ -333,6 +349,7 @@ def field(*, mandatory=True, default=None, default_function=None, cache=None,
     ----------
     **kwargs
         Parameters for `dataclasses.field` (with the other ones before them for `Data`).
+        `default_factory` is forbidden.
 
     """
     return dataclasses.field(
@@ -389,6 +406,7 @@ def dyn_field(*, mandatory=True, default=None, default_function=None, cache=None
     ----------
     **kwargs
         Parameters for `dataclasses.field` (with the other ones before them for `Data`).
+        `default_factory` is forbidden.
 
     """
     validate = _canonicalize_callables(validate)
@@ -419,7 +437,7 @@ def fxd_field(*, mandatory=True, default=None, default_function=None, cache=None
     ----------
     **kwargs
         Parameters for `dataclasses.field` besides `repr` (with the other ones before
-        them for `Data`).
+        them for `Data`). `default_factory` is forbidden.
 
     """
     validate = _canonicalize_callables(validate)
@@ -449,7 +467,7 @@ def aux_field(*, mandatory=True, default=None, default_function=None, cache=None
     ----------
     **kwargs
         Parameters for `dataclasses.field` besides `repr` (with the other ones before
-        them for `Data`).
+        them for `Data`). `default_factory` is forbidden.
 
     """
     kwargs = _update_metadata(kwargs, FType.AUXILIARY)
@@ -521,6 +539,7 @@ class Tree(ABC):
                 if value is not self:
                     descr.__set__(self, value)
 
+    #TODO warn reserved member names replace, cache, & purge. How?
     def replace(self, **changes):
         """Create a new object of the same type, replacing fields with changes.
 
@@ -662,12 +681,12 @@ def pytree_dataclass(cls, *, frozen=True, **kwargs):
     >>> @pytree_dataclass
     ... class Parameters(TanMixin, Tree):
     ...     dtype: DTypeLike = aux_field(default=jnp.complex64,
-    ...                                  validate=issubdtype_of(jnp.complexfloating)
+    ...                                  validate=issubdtype_of(jnp.complexfloating),
     ...                                  repr=True)
     ...     theta: ArrayLike = dyn_field(default=jnp.array([0, 1, 1j]),
     ...                                  validate=asarray_of(field='dtype'))
     ...     const: ArrayLike = fxd_field(default=jnp.array([2.7182818, 3.1415926]),
-    ...                                  validate=jnp.float32
+    ...                                  validate=jnp.float32,
     ...                                  repr=True)
     >>> print(Parameters())
     Parameters(dtype=<class 'jax.numpy.complex64'>,

--- a/pmwd/util.py
+++ b/pmwd/util.py
@@ -7,7 +7,7 @@ def is_float0_array(obj):
 
 
 def float0_like(array):
-    return np.empty(array.shape, dtype=float0)  # see jax issues #4433, #19386, #20620
+    return np.empty(array.shape, dtype=float0)  # see JAX issues #4433, #19386, #20620
 
 
 def add(a, b):

--- a/pmwd/util.py
+++ b/pmwd/util.py
@@ -1,11 +1,47 @@
 import numpy as np
-from jax import float0
-import jax.numpy as jnp
+from jax.dtypes import float0
 
 
-def is_float0_array(x):
-    return isinstance(x, np.ndarray) and x.dtype == float0
+def is_float0_array(obj):
+    return isinstance(obj, np.ndarray) and obj.dtype == float0
 
 
-def float0_like(x):
-    return np.empty(x.shape, dtype=float0)  # see jax issue #4433
+def float0_like(array):
+    return np.empty(array.shape, dtype=float0)  # see jax issues #4433, #19386, #20620
+
+
+def add(a, b):
+    """Like ``operator.add`` with simplest ``float0`` handling (no broadcasting)."""
+    if is_float0_array(a) and is_float0_array(b):
+        if a.shape != b.shape:
+            raise ValueError(f'float0 array shapes mismatch: {a.shape} != {b.shape}')
+        return a
+    return a + b
+
+
+def sub(a, b):
+    """Like ``operator.sub`` with simplest ``float0`` handling (no broadcasting)."""
+    if is_float0_array(a) and is_float0_array(b):
+        if a.shape != b.shape:
+            raise ValueError(f'float0 array shapes mismatch: {a.shape} != {b.shape}')
+        return a
+    return a - b
+
+
+def neg(obj):
+    """Like ``operator.neg`` with ``float0`` handling."""
+    return obj if is_float0_array(obj) else -obj
+
+
+def scalar_mul(scalar, array):
+    """Scalar multiplication with ``float0`` handling."""
+    if is_float0_array(array):
+        return array
+    return scalar * array
+
+
+def scalar_div(scalar, array):
+    """Division by scalar with ``float0`` handling."""
+    if is_float0_array(array):
+        return array
+    return array / scalar

--- a/pmwd/vis_util.py
+++ b/pmwd/vis_util.py
@@ -10,6 +10,18 @@ from matplotlib.colors import FuncNorm
 #    pass  # if not plotting in Jupyter
 
 
+# TODO Underdense cmap with bone_r, or the first half of twilight
+#      Where to join the two depends on visual
+#      Alternatives replacing bone_r + inferno with twilight, which is cyclic, but need to
+
+# TODO the "dna" cmap, because of double helix
+#      Use CAM16-UCS to make inferno like and its partner strand
+#      https://colour.readthedocs.io/en/latest/colour.html
+#      colour.CAM16UCS_to_XYZ, colour.XYZ_to_RGB  # which RGB?
+#      https://en.wikipedia.org/wiki/Color_appearance_model#CAM16
+#      or OKLab https://en.wikipedia.org/wiki/Oklab_color_space
+
+
 def simshow(x, figsize=(6.3, 4.9), dpi=96, cmap='inferno', norm=None, colorbar=True,
             interpolation='lanczos', interpolation_stage='rgba', **kwargs):
     """Plot a 2D view of simulation with ``imshow``.
@@ -33,7 +45,7 @@ def simshow(x, figsize=(6.3, 4.9), dpi=96, cmap='inferno', norm=None, colorbar=T
     interpolation_stage : {'data', 'rgba'}, optional
         For ``matplotlib.axes.Axes.imshow``. Unlike in ``imshow``, the default is
         'rgba'.
-    **kwargs :
+    **kwargs
         Other keyword arguments to be passed to ``matplotlib.axes.Axes.imshow``.
 
     Returns
@@ -76,7 +88,7 @@ def simshow(x, figsize=(6.3, 4.9), dpi=96, cmap='inferno', norm=None, colorbar=T
 class CosmicWebNorm(FuncNorm):
     """Colormap normalization for cosmic web (relative) density fields.
 
-    Use ``plot()`` to look at the normalization transformations.
+    Call `plot` to look at the normalization transformations.
 
     Parameters
     ----------
@@ -111,9 +123,9 @@ class CosmicWebNorm(FuncNorm):
     """
     def __init__(self, x, q=0.1, gamma=0.5, fit_min=1e-2, fit_num=64, clip=False):
         if not 0 < q < 1:
-            raise ValueError(f'q = {q} not in (0, 1)')
+            raise ValueError(f'{q = } not in (0, 1)')
         if gamma <= 0:
-            raise ValueError(f'gamma = {gamma} <= 0')
+            raise ValueError(f'{gamma = } <= 0')
 
         x = np.asarray(x)
 

--- a/pmwd/vis_util.py
+++ b/pmwd/vis_util.py
@@ -22,18 +22,22 @@ from matplotlib.colors import FuncNorm
 #      or OKLab https://en.wikipedia.org/wiki/Oklab_color_space
 
 
-def simshow(x, figsize=(6.3, 4.9), dpi=96, cmap='inferno', norm=None, colorbar=True,
-            interpolation='lanczos', interpolation_stage='rgba', **kwargs):
-    """Plot a 2D view of simulation with ``imshow``.
+def simshow(x, figsize=(6.3, 4.9), dpi=96, figax=None, cmap='inferno', norm=None,
+            colorbar=True, interpolation='lanczos', interpolation_stage='rgba',
+            **kwargs):
+    """Plot a 2D view of simulation with matplotlib ``imshow``.
 
     Parameters
     ----------
     x : ArrayLike
         2D field.
     figsize : 2-tuple of float, optional
-        Width and height in inches.
+        Width and height in inches for a new figure if `figax` is `None`.
     dpi : float, optional
-        Figure resolution in dots-per-inch.
+        Dots-per-inch resolution for a new figure if `figax` is `None`.
+    figax : 2-tuple or None, optional
+        Existing ``Figure`` and ``Axes`` instances. Useful for more customization, e.g.,
+        when this is one of multiple subplots.
     cmap : str or ``matplotlib.colors.Colormap``, optional
         For ``matplotlib.axes.Axes.imshow``.
     norm : 'CosmicWebNorm' or ``matplotlib.colors.Normalize``, optional
@@ -52,6 +56,7 @@ def simshow(x, figsize=(6.3, 4.9), dpi=96, cmap='inferno', norm=None, colorbar=T
     -------
     fig : ``matplotlib.figure.Figure``
     ax : ``matplotlib.axes.Axes``
+    im : ``matplotlib.image.AxesImage``
 
     """
     x = np.asarray(x)
@@ -59,7 +64,7 @@ def simshow(x, figsize=(6.3, 4.9), dpi=96, cmap='inferno', norm=None, colorbar=T
     if norm == 'CosmicWebNorm':
         norm = CosmicWebNorm(x)
 
-    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi) if figax is None else figax
 
     im = ax.imshow(
         x,
@@ -82,7 +87,7 @@ def simshow(x, figsize=(6.3, 4.9), dpi=96, cmap='inferno', norm=None, colorbar=T
                           bottom=False, top=False, left=False, right=False)
         cb.outline.set_visible(False)
 
-    return fig, ax
+    return fig, ax, im
 
 
 class CosmicWebNorm(FuncNorm):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     use_scm_version={'write_to': 'pmwd/_version.py'},
     setup_requires=['setuptools_scm'],
     packages=find_packages(),
-    python_requires='>=3.8',  # math.prod
+    python_requires='>=3.8',  # math.prod  # https://jax.readthedocs.io/en/latest/deprecation.html
     install_requires=[
         'jax>=0.4.7',
         'mcfit>=0.0.18',  # jax backend

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     use_scm_version={'write_to': 'pmwd/_version.py'},
     setup_requires=['setuptools_scm'],
     packages=find_packages(),
-    python_requires='>=3.8',  # math.prod  # https://jax.readthedocs.io/en/latest/deprecation.html
+    python_requires='>=3.11',  # https://jax.readthedocs.io/en/latest/deprecation.html
     install_requires=[
         'jax>=0.4.7',
         'mcfit>=0.0.18',  # jax backend


### PR DESCRIPTION
The units, constants, dtype settings, transfer settings, growth settings, and linear variance settings in `Configuration` couple more tightly with `Cosmology`, and should be moved there. After that `boltzmann.py` can also be independent of `Configuration`,  and functions like [`jax-cosmo`](https://github.com/DifferentiableUniverseInitiative/jax_cosmo) together with `cosmology.py`.

Likewise, I also try to make `Particles` more independent of conf. And have some different dtype design for `Cosmology` and `Particles`.

To accommodate new features, e.g., sCOLA-like parallelization and observables, the plan is to change the old API
```python
conf = Configuration(...)
cosmo = Cosmology(conf, ...)
modes = white_noise(seed, conf)

def model(modes, ptcl, obsvbl, cosmo, solver):
    cosmo = boltzmann(cosmo, conf)
    modes = linear_modes(modes, cosmo, conf)
    ptcl, obsvbl = lpt(modes, cosmo, conf)
    ptcl, obsvbl = nbody(ptcl, obsvbl, cosmo, conf)
    return obj(obsvbl)
```
to
```python
def config(...):
    cosmo = Cosmology(...)

    solver = Solver(...)  # the old Configuration, hierarchical, sub-solvers with boundary conditions (BCs)
    modes = white_noise(seed, solver)
    ptcl = pre_init_cond(...)  # or None, to be generated from solver, as additional input to lpt
    obsvbl = Snapshots(...), Lightcone(...)  # observable settings, as additional input to lpt

    return modes, ptcl, obsvbl, cosmo, solver

def model(modes, ptcl, obsvbl, cosmo, solver):
    cosmo = cosmo.cache()  # changed from boltzmann.boltzmann()
    #traverse solver (ptcl and modes too?) pytree (depth/breadth first? flatten is former)
    return obj(traverse(solve(modes, ptcl, obsvbl, cosmo, solver)))

def solve(modes, ptcl, obsvbl, cosmo, solver):
    modes = linear_modes(None, modes, cosmo, solver)  # a=None dependence is moved to front and made explicit
    ptcl, obsvbl, solver = lpt(modes, ptcl, obsvbl, cosmo, solver)  # compute BCs for all sub-solvers
    ptcl, obsvbl, solver = nbody(ptcl, obsvbl, cosmo, solver)  # lpt and nbody also calls obj_imdt -> obsvbl
    obsvbl, solver = obj(obsvbl, solver)  # compute current level obj -> obsvbl
    return obsvbl, solver
```

Discussions and comments are welcome.