### PR TITLE
Fix Cosmology.from_sigma8() for a_stop!=1

### DIFF
--- a/pmwd/__init__.py
+++ b/pmwd/__init__.py
@@ -12,7 +12,7 @@ from pmwd.gather import gather
 from pmwd.gravity import laplace, neg_grad, gravity
 from pmwd.modes import white_noise, linear_modes
 from pmwd.lpt import lpt
-from pmwd.nbody import nbody
+from pmwd.nbody import nbody, nbody_scan
 try:
     from pmwd._version import __version__
 except ModuleNotFoundError:

--- a/pmwd/boltzmann.py
+++ b/pmwd/boltzmann.py
@@ -284,6 +284,7 @@ def varlin_integ(cosmo, conf):
         ``(len(conf.varlin_R),)`` and ``conf.cosmo_dtype``.
 
     """
+    # no scale factor specified here!!!
     Plin = linear_power(conf.var_tophat.x, None, cosmo, conf)
 
     _, varlin = conf.var_tophat(Plin, extrap=True)

--- a/pmwd/configuration.py
+++ b/pmwd/configuration.py
@@ -313,11 +313,17 @@ class Configuration:
         """N-body time integration scale factor steps, including ``a_start``, of ``cosmo_dtype``."""
         return jnp.linspace(self.a_start, self.a_stop, num=1+self.a_nbody_num,
                             dtype=self.cosmo_dtype)
+    
+    @property
+    def growth_a_num(self):
+        """Number of growth factor points."""
+        return math.ceil(1. / self.a_lpt_maxstep)
 
     @property
     def growth_a(self):
         """Growth function scale factors, for both LPT and N-body, of ``cosmo_dtype``."""
-        return jnp.concatenate((self.a_lpt, self.a_nbody[1:]))
+        return jnp.linspace(0., 1., num=self.growth_a_num,
+                            dtype=self.cosmo_dtype)
 
     @property
     def varlin_R(self):

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -99,6 +99,7 @@ class Cosmology:
 
         cosmo = cls(conf, 1, *args, **kwargs)
         cosmo = boltzmann(cosmo, conf)
+        print(sigma8, cosmo.sigma8)
 
         A_s_1e9 = (sigma8 / cosmo.sigma8)**2
 
@@ -153,7 +154,7 @@ class Cosmology:
         """Linear matter rms overdensity within a tophat sphere of 8 Mpc/h radius at a=1."""
         from pmwd.boltzmann import varlin
         R = 8 * self.conf.Mpc_SI / self.conf.L
-        return jnp.sqrt(varlin(R, 1, self, self.conf))
+        return jnp.sqrt(varlin(R, 1., self, self.conf))
 
     @property
     def ptcl_mass(self):

--- a/pmwd/cosmology.py
+++ b/pmwd/cosmology.py
@@ -99,7 +99,6 @@ class Cosmology:
 
         cosmo = cls(conf, 1, *args, **kwargs)
         cosmo = boltzmann(cosmo, conf)
-        print(sigma8, cosmo.sigma8)
 
         A_s_1e9 = (sigma8 / cosmo.sigma8)**2
 


### PR DESCRIPTION
In #30 Adrian mentioned that current growth function is tabulated between `a_start` and `a_stop`, and the growth function gives wrong values for input scale factor out of the region because of the extrapolation behavior of `jax.numpy.interp`. This can be fixed by always tabulating the growth from a=0 to a=1 in the `configration`. 